### PR TITLE
Replace rack-slashenforce with rack-rewrite

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem "RedCloth", "4.2.9"
 gem "sass"
 gem "coderay"
 gem "govuk_frontend_toolkit", "0.12.3"
-gem "rack-slashenforce"
+gem "rack-rewrite"
 gem 'thin'
 gem 'foreman'
 gem 'kramdown'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,8 +74,7 @@ GEM
     rack (1.4.4)
     rack-cache (1.2)
       rack (>= 0.4)
-    rack-slashenforce (0.0.2)
-      rack
+    rack-rewrite (1.3.3)
     rack-ssl (1.3.3)
       rack
     rack-test (0.6.2)
@@ -127,6 +126,6 @@ DEPENDENCIES
   govuk_frontend_toolkit (= 0.12.3)
   jekyll
   kramdown
-  rack-slashenforce
+  rack-rewrite
   sass
   thin

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,4 @@
-require "rack-slashenforce"
+require "rack-rewrite"
 
 USERNAME = ENV['AUTH_USERNAME']
 PASSWORD = ENV['AUTH_PASSWORD']
@@ -7,7 +7,16 @@ use Rack::Auth::Basic, "Restricted" do |username, password|
   [username, password] == [USERNAME, PASSWORD]
 end
 
-use Rack::AppendTrailingSlash
+use Rack::Rewrite do
+  # Rewrite any requests that contain no dots and end without a trailing slash
+  # to contain a trailing slash. This makes Rack::Static do the right thing
+  # for directories, and enforces consistency with the style of the rest of
+  # GOV.UK.
+  rewrite %r{^([^.]+[^/])$}, '$1/'
+  # Redirect any requests that end with a slash to the equivalent without the
+  # trailing slash.
+  r301 %r{^(.+?)/+$}, '$1'
+end
 
 use Rack::Static, :urls => [""], :root => "_site", :index => "index.html"
 


### PR DESCRIPTION
Changing the URLs of the "directory" pages (e.g. `/about` -> `/about/`) isn't 
ideal, as it's a) inconsistent with the rest of GOV.UK, and b) it breaks the 
existing annotations on pages without slashes.

This commit replaces `rack-slashenforcer` with `rack-rewrite`, and makes the 
slashless versions of the pages work.
