### PR TITLE
Fix "Further Reading" in operations/monitoring

### DIFF
--- a/service-manual/operations/monitoring.md
+++ b/service-manual/operations/monitoring.md
@@ -48,6 +48,6 @@ The monitoring system, or rather any dashboards, interactive tools or reports, s
 
 ## Further reading
 
-* [Radiating Information](http://digital.cabinetoffice.gov.uk/2012/02/08/radiating-information/)Examples of some of the monitoring dashboards used while building GOV.UK
-* [Open Source Monitoring](https://speakerdeck.com/obfuscurity/the-state-of-open-source-monitoring) 
+* [Radiating Information](http://digital.cabinetoffice.gov.uk/2012/02/08/radiating-information/) gives examples of some of the monitoring dashboards used while building GOV.UK
+* [Open Source Monitoring](https://speakerdeck.com/obfuscurity/the-state-of-open-source-monitoring) explains some of the terminology and available open-source tools
 


### PR DESCRIPTION
- Separate _Radiating Information_ from the explanation using a space
- Change explanation to be a readable sentence flowing from link title
- Add an explanation of the _Open Source Monitoring_ slide deck
