### PR TITLE
Remove code styling from within links

### DIFF
--- a/service-manual/design-and-content/resources/sass-repositories.md
+++ b/service-manual/design-and-content/resources/sass-repositories.md
@@ -29,7 +29,7 @@ The second is a way to develop responsive sites while not giving older browsers 
 
 The third is a way to keep browser specific styles out of our projects. We encapsulate new or non-standardised CSS into mixins. In this way we can easily update all the instances of a new CSS property without having to do a search and replace across all of our projects.
 
-For a full list of the different Sass techniques we have available look at the [readme on the `govuk_frontend_toolkit` gem](https://github.com/alphagov/govuk_frontend_toolkit).
+For a full list of the different Sass techniques we have available look at the [readme on the govuk_frontend_toolkit gem](https://github.com/alphagov/govuk_frontend_toolkit).
 
 ## Typography and Colours
 
@@ -82,4 +82,4 @@ The `border-radius` line here is designed to use the different border-radius imp
 
 ## Further reading
 
-For more information check out the Readme on the [`govuk_frontend_toolkit` gem](https://github.com/alphagov/govuk_frontend_toolkit)
+For more information check out the Readme on the [govuk_frontend_toolkit gem](https://github.com/alphagov/govuk_frontend_toolkit)


### PR DESCRIPTION
I think it's quite jarring to have the text within a link styled as code too - within those links I don't think there's any harm in just having the text as text.
