### PR TITLE
Strengthen guidance on accessibility and content

### DIFF
--- a/service-manual/design-and-content/choosing-appropriate-formats.md
+++ b/service-manual/design-and-content/choosing-appropriate-formats.md
@@ -24,13 +24,15 @@ Almost all content relating to the policies or publications of government depart
 
 ## Choose the format to fit the content
 
-You should publish documents in formats that reflect the format of the information they contain, and the uses to which they will likely be put.
+You should publish documents in file formats that reflect the nature of the information they contain, and the uses to which they will likely be put.
 
-- For tabular data, use [CSV](https://en.wikipedia.org/wiki/Comma-separated_values) or a similar "structured data" format (see also [JSON](https://en.wikipedia.org/wiki/JSON) and [XML](https://en.wikipedia.org/wiki/XML)). Do not publish structured data in unstructured formats such as PDF.
+- For written reports, the native format of the web (HTML) should be your default option. PDF can be an excellent display format, but without additional effort it can be inappropriate for users of screenreading software. It is faster and easier to make accessible HTML that is suitable for every platform and device. If you must publish PDFs, you should provide accessible alternate formats for the document, and invest effort in [accessibility tagging your PDFs](/service-manual/design-and-content/resources/creating-accessible-PDFs.html).
 
-- For written reports, consider the accessibility of your report to your readers. PDF can be an excellent display format, but without additional effort it can be inappropriate for users of screenreading software. You might use a more accessible format such as HTML, provide accessible alternate formats for the document, or invest effort in [accessibility tagging your PDFs](/service-manual/design-and-content/resources/creating-accessible-PDFs.html).
+- For data, use [CSV](https://en.wikipedia.org/wiki/Comma-separated_values) or a similar "structured data" format (see also [JSON](https://en.wikipedia.org/wiki/JSON) and [XML](https://en.wikipedia.org/wiki/XML)). Do not publish structured data in unstructured formats such as PDF.
 
-If you are publishing tabular information (financial reports, statistical data, etc.) then your users may well wish to process this data programmatically. By publishing in a "machine-readable" format such as CSV, you are helping them do so with minimal additional effort. Similarly, by making available accessible versions of textual reports, you are ensuring that you do not exclude users who have every right to receive your publications.
+- If you are regularly publishing data (financial reports, statistical data, etc.) then your users may well wish to process this data programmatically, and it becomes especially important that your data is "machine-readable." PDFs, Word documents and the like are not suitable formats for data publication. In addition, you should consider making your data available through an API if this will simplify your users' interactions with your publications. For more information on APIs, and for more detailed technical guides on publishing data, please see [our guidance on APIs and formats](/service-manual/making-software/apis.html#representations-are-for-the-consumer).
+
+- If you are publishing a written report that contains statistical tables, provide the tables alongside or in addition to your report in suitable data formats.
 
 In summary, consider your users, and the uses to which they will put your published data and content. If in doubt, treat the native format of the web, HTML, as a good fallback option. Web browsers are available on all platforms and devices, and web pages tend to be both passably accessible and machine-readable.
 
@@ -38,12 +40,16 @@ In summary, consider your users, and the uses to which they will put your publis
 
 Wherever possible, publish in accessible, patent-free, [open formats](https://en.wikipedia.org/wiki/Open_format), for which software is widely available on a variety of platforms. If publishing in proprietary formats, you should always make a non-proprietary alternative available.
 
-- For textual reports, provide HTML, plain text (.txt), or PDF rather than formats that require proprietary software to view, such as Word documents (.doc).
+- For textual reports, provide HTML, plain text (.txt), or PDF rather than formats that require proprietary software to view, such as Word documents (.doc/.docx).
 
-- For tabular data, provide CSV or [TSV](https://en.wikipedia.org/wiki/Tab-separated_values) rather than Excel spreadsheets (.xls).
+- For tabular data, provide CSV or [TSV](https://en.wikipedia.org/wiki/Tab-separated_values) rather than Excel spreadsheets (.xls/.xlsx).
+
+- For other structured data, see our guidance on [representations for the
+  consumer](/service-manual/making-software/apis.html#representations-are-for-the-consumer). Wherever possible, choose an open format over a proprietary one.
 
 Again, if in doubt, you should treat the native format of the web, HTML, as your best default option.
 
+*[API]: Application Programming Interface
 *[CSV]: Comma-separated values
 *[TSV]: Tab-separated values
 *[PDF]: Portable Document Format

--- a/service-manual/making-software/apis.md
+++ b/service-manual/making-software/apis.md
@@ -80,6 +80,8 @@ Where possible, also offer other formats most suited to a specific domain, such 
 - [KML](http://en.wikipedia.org/wiki/Keyhole_Markup_Language) and [geoRSS](http://en.wikipedia.org/wiki/GeoRSS) for geographical data
 - [m3u](http://en.wikipedia.org/wiki/.m3u) for playlists
 
+_This advice builds on our [more general guidance on data and content publication formats](/service-manual/design-and-content/choosing-appropriate-formats.html)._
+
 Include hyperlinks to alternative representations as [link headers](http://www.w3.org/TR/html51/document-metadata.html#the-link-element) as well as in content.
 
 _Consider also encoding meta-data inside HTML content using semantic markup: [Microformats](http://microformats.org/). [RDFa](http://en.wikipedia.org/wiki/Rdfa) or [schema.org](http://schema.org/)._


### PR DESCRIPTION
A number of wording tweaks. In general I've made the guidance on accessible
formats and open standards stronger, and made clear that Léonie's guidance on
making PDFs accessible is help for a "last resort" situation, and not our
desired publication method.

In addition, I've added the cross-referencing chatted about with @psd.
