### PR TITLE
Add a shallower on-ramp to information security

### DIFF
--- a/service-manual/making-software/information-security.md
+++ b/service-manual/making-software/information-security.md
@@ -134,9 +134,9 @@ above groups.
 
 Business Impact Levels, often shorted to Impact Levels (IL) are a set of numbers used to guide discussions of risk in Government projects. Specifically they are numbers between 0 and 6 for each of the three "key concepts" mentioned above, and measure:
 
-* IL confidentiality: the potential impact if the information is seen by those who should not see it
-* IL integrity: the potential impact if the accuracy or completeness of the information is compromised
-* IL availability: the potential impact if the information becomes inaccessible
+* For confidentiality: the potential impact if the information is seen by those who should not see it
+* For integrity: the potential impact if the accuracy or completeness of the information is compromised
+* For availability: the potential impact if the information becomes inaccessible
 
 More details about identifying these numbers can be found in this [extract from HMG IA Standard No. 1](http://www.cesg.gov.uk/publications/Documents/business_impact_tables.pdf).
 


### PR DESCRIPTION
The existing information security documentation launched somewhat abruptly
into the sea of jargon and acronyms that is information assurance in
government. I've tried to provide a slightly more user-friendly lead-up,
explaining first what information security is and how it's practised,
before getting to the government-specific bits.

I've tried to keep it as concise as possible without getting overly dense. Let
me know if you think I haven't got the balance right.

I also think we should provide a small amount of technical guidance on security
best practices in web application development, which should probably be linked
from here. Do people agree that this is currently lacking from the manual? I'm
thinking of basic introductions to:
- threat modelling
- defense in depth
- the dangers of proprietary cryptographic systems
- existing security standards and commonly employed cryptosystems
