### PR TITLE
APIs copyedit

### DIFF
--- a/service-manual/making-software/apis.md
+++ b/service-manual/making-software/apis.md
@@ -20,7 +20,7 @@ breadcrumbs:
     url: /service-manual/making-software
 ---
     
-[Martha Lane Fox's report](https://www.gov.uk/government/publications/directgov-2010-and-beyond-revolution-not-evolution-a-report-by-martha-lane-fox) called for government to act as a "wholesaler as well as the retail shop front for services and content by mandating the development and opening up of Application Programme Interfaces [APIs](http://en.wikipedia.org/wiki/Application_programming_interface) to third parties." 
+[Martha Lane Fox's report](https://www.gov.uk/government/publications/directgov-2010-and-beyond-revolution-not-evolution-a-report-by-martha-lane-fox) called for government to act as a "wholesaler as well as the retail shop front for services and content by mandating the development and opening up of Application Programme Interfaces ([APIs](http://en.wikipedia.org/wiki/Application_programming_interface)) to third parties." 
 
 This section is a set of guiding principles for exposing a digital service as an API.
 


### PR DESCRIPTION
Copyediting for the APIs page. Mostly small changes around capitalization and consistency, with one rewording for clarity.
