### PR TITLE
Remove fullstops from notations

### DIFF
--- a/service-manual/agile/features-of-agile.md
+++ b/service-manual/agile/features-of-agile.md
@@ -47,7 +47,7 @@ The normal format is each person answers the following 3 questions:
 
 * what I worked on/delivered yesterday
 * what I am working on today (and help I might need)
-* what’s blocking me (i.e. stopping me delivering a story card)
+* what’s blocking me (ie stopping me delivering a story card)
 
 (It sometimes helps to have an object that you (gently) throw randomly to the a person in the stand-up to signify they should speak next. It keeps people on their toes, the randomness stops it feeling too repetitive and allows the last person that speaks to choose the person they wish to hear from next. At GDS we use cuddly toys or a piece of fruit. It’s a bit of fun. You don’t have to this, it’s just something to experiment with.)
 
@@ -67,7 +67,7 @@ With bigger teams this can be a hard meeting to get right. Some people want to d
 
 Some teams choose to write or refine their stories at a single, set time within their sprint cycle, others choose to do it over a couple of sessions. It’s up to you, but don’t miss it. It’s vital that you have good stories and there has been constructively discussed with relevant team members, subject matter experts and stakeholders in good time, ahead of sprint planning.
 
-Make sure stories are well formed (i.e. don’t skip the “So that...” part because it’s hard), have a good, sensible list of acceptance criteria that supplement your teams’ standing criteria for ‘definition of done’ and are estimated. If stories are too big then split them into smaller stories. They stand more chance of delivering shippable code.
+Make sure stories are well formed (ie don’t skip the “So that...” part because it’s hard), have a good, sensible list of acceptance criteria that supplement your teams’ standing criteria for ‘definition of done’ and are estimated. If stories are too big then split them into smaller stories. They stand more chance of delivering shippable code.
 
 ### Sprint Review
 

--- a/service-manual/agile/running-retrospectives.md
+++ b/service-manual/agile/running-retrospectives.md
@@ -28,7 +28,7 @@ One of the central principles of agile is quick feedback loops – we want to de
 {:.left}
 ![X-prop retrospective](https://farm9.staticflickr.com/8013/7105598457_084223078e_d.jpg)
 
-A retrospective is a meeting at the end of a [sprint](/service-manual/agile/features-of-agile.html) where the team get a chance to talk about what went well and badly in that sprint, and take some actions to improve matters. It can also cover a larger scope, e.g. a full project retrospective.
+A retrospective is a meeting at the end of a [sprint](/service-manual/agile/features-of-agile.html) where the team get a chance to talk about what went well and badly in that sprint, and take some actions to improve matters. It can also cover a larger scope, eg a full project retrospective.
 
 A retrospective takes the following form:
 
@@ -72,7 +72,7 @@ The outcome of a retrospective should be some actions that can be taken to impro
 
 Actions should:
 
-* be concrete and measurable (e.g. 'write 10 more unit tests for the redirector', or 'speak to Jamie about arranging a project retrospective'; not 'write more tests', or 'we should understand the lessons learned from this project')
+* be concrete and measurable (eg 'write 10 more unit tests for the redirector', or 'speak to Jamie about arranging a project retrospective'; not 'write more tests', or 'we should understand the lessons learned from this project')
 * have a date by which they should be completed
 * be assigned to a specific person (and not to 'the team')
 * should not be assigned to someone who is not present

--- a/service-manual/agile/what-agile-looks-like.md
+++ b/service-manual/agile/what-agile-looks-like.md
@@ -62,7 +62,7 @@ A good team includes members with all of the skills necessary to successfully de
 
 *Product Manager* - responsible for delivering return on investment, usually by creating products that users love.  The team delivers the Product Manager’s vision.
 
-*Delivery Manager* (a.k.a. Scrum master or Project Manager) - is the agile expert that is responsible for removing blockers (things slowing a team down).  They also usually act as a facilitator at team get togethers.
+*Delivery Manager* (aka Scrum master or Project Manager) – is the agile expert that is responsible for removing blockers (things slowing a team down).  They also usually act as a facilitator at team get togethers.
 
 *Team member* - Self organising, multi-disciplinary team that delivers prioritised user stories. Responsible for estimation.
 

--- a/service-manual/agile/writing-user-stories.md
+++ b/service-manual/agile/writing-user-stories.md
@@ -52,7 +52,7 @@ Building useful software systems is hard. How can we make sure we're solving the
 
 Agile methodologies emphasise an outside-in approach – what outcome is your service user trying to achieve? If we dive into the solution without a good understanding of our users, we risk solving the wrong problem, or coming up with solutions which don't really work for our users in the real world. That's why the most important part of a user story is the **GOAL**. 
 
-You can also use this goal to help you decide whether the story is "done" or delivered. i.e. Does the work that's been done meet the goal? 
+You can also use this goal to help you decide whether the story is "done" or delivered. ie Does the work that's been done meet the goal? 
 
 As a service manager writing stories with your development team, always start by thinking about and discussing your users' goals. Why do they want to use your service? What are they trying to achieve? What need has motivated them to seek out your service? In what context do they use it? At home? At work? On a mobile phone? Whilst caring for a child? How often? Suzanne and James Robertson have excellent advice on this in Mastering the Requirements Process ([reference 1](#references)).
 

--- a/service-manual/assisted-digital/index.md
+++ b/service-manual/assisted-digital/index.md
@@ -35,7 +35,7 @@ Services will need to consider the digital skills of their users to understand w
 * could use the digital service independently but will require initial assisted digital support to build their confidence in using the service 
 * should use the digital service (ie. have the digital skills but currently use other channels) and don’t need assisted digital support
 
-Some services (e.g. where users are large corporations) will not require assisted digital. The [Digital Landscape Research](http://publications.cabinetoffice.gov.uk/digital/research/#fig-5) contains a demographic breakdown of who is offline and online and service teams and [these techniques](/service-manual/users/user-research/index.html) may be useful for doing user research.
+Some services (eg where users are large corporations) will not require assisted digital. The [Digital Landscape Research](http://publications.cabinetoffice.gov.uk/digital/research/#fig-5) contains a demographic breakdown of who is offline and online and service teams and [these techniques](/service-manual/users/user-research/index.html) may be useful for doing user research.
 
 ## What good looks like
 Good assisted digital support:

--- a/service-manual/design-and-content/data-visualisation.md
+++ b/service-manual/design-and-content/data-visualisation.md
@@ -37,7 +37,7 @@ The [GOV.UK Performance Platform](https://www.gov.uk/performance) helps the Gove
 
 To effectively tell the story behind the numbers, you need to understand both your audience and the data.
 
-Only use visualisations if they make the story clearer. In many cases, a good table or words may communicate better. If there are very few data points (e.g. top rate income tax down 5%, all other rates unchanged), it’s clearer to write a sentence than draw a picture. If every item must be read precisely (to several decimal places) then a table is best.
+Only use visualisations if they make the story clearer. In many cases, a good table or words may communicate better. If there are very few data points (eg top rate income tax down 5%, all other rates unchanged), it’s clearer to write a sentence than draw a picture. If every item must be read precisely (to several decimal places) then a table is best.
 
 A good table will be clear and uncluttered. The data should be easy to read with the same decimal places or rounding and sorted into a logical order. Don't use too many different types of font, and make sure your data is referenced.
 
@@ -70,13 +70,13 @@ Strengths - comparing **items**, or a small number of time periods.
 
 Strengths - comparing **items**, especially if they have long names or many items.
 
-* Arrange bars in size order, from biggest to smallest (unless good reason i.e.data needs to be represented alphabetically).
+* Arrange bars in size order, from biggest to smallest (unless there's good reason, ie data needs to be represented alphabetically).
 * Negative values to the left of the y axis.
 
 ###Line chart
 ![Line Chart - Image 3](https://docs.google.com/drawings/pub?id=1EPgsC32JClcIjApetWMFHLPNSZQEoViSacc0ySmclp4&w=337&h=237)
 
-Strengths - comparing over time or between **variables** for a **single item** (eg: site traffic vs site performance)
+Strengths - comparing over time or between **variables** for a **single item** (eg site traffic vs site performance)
 
 * Limit number of data sets to four.
 * Keep axis labels horizontal.
@@ -93,7 +93,7 @@ Strengths - simple share of **total**. Use with caution, column or bar charts ar
 ###Scatter chart
 ![Scatter Chart - Image 5](https://docs.google.com/drawings/pub?id=1yBH8YxdFGHM4N9xXuZeD4M9CIVcxYicfRznktcSLDKw&w=337&h=237)
 
-Strengths - relationships between **variables** where there are **many items** (eg: volume vs cost for numerous transactions)
+Strengths - relationships between **variables** where there are **many items** (eg volume vs cost for numerous transactions)
 
 * Limit items to two to avoid confusion.
 * Include trend line if required. This should be a single solid line.
@@ -127,7 +127,7 @@ Choosing the correct visualisation is important and at GDS we reviewed what was 
 
 Keep in mind these useful tips when creating your charts.
 
-* Start axes at zero unless there's good reason not to (ie: data is clustered at high values).
+* Start axes at zero unless there's good reason not to (ie data is clustered at high values).
 * Do not say too much, limit the number of data sets.
 * If needed, put legend at the top of the chart in the same order as the data in the chart.
 * Maximise the space available to the chart and remove chartjunk.
@@ -185,7 +185,7 @@ When presenting data be aware of axes and scales. Data can be misrepresented by 
 
 ###Checklist
 1. Have you referenced data with a URL?
-2. Have you provided contact details (e.g. a mailto link)?
+2. Have you provided contact details (eg a mailto link)?
 3. Is it clear whether data is internal or public?
 4. Have you been open and transparent with data?
 

--- a/service-manual/design-and-content/resources/writing-for-transactions.md
+++ b/service-manual/design-and-content/resources/writing-for-transactions.md
@@ -76,7 +76,7 @@ This is the nuclear option and should only be considered as a last resort. Popup
 
 ## Transaction start pages
 
-The start point for any GOV.UK transaction should be a page on the GOV.UK domain. Users should not be able to jump to a later page in the service via some other means (e.g. Google).
+The start point for any GOV.UK transaction should be a page on the GOV.UK domain. Users should not be able to jump to a later page in the service via some other means (eg Google).
 
 The design of the start page will be determined by the nature of the service and its audience. All start pages should meet the following goals:
 

--- a/service-manual/digital-by-default/index.md
+++ b/service-manual/digital-by-default/index.md
@@ -39,7 +39,7 @@ A team must demonstrate that they have done the following to achieve the standar
 13. used the manual to develop the content and design to ensure the service has the same look, feel and tone as GOV.UK
 14. got the capacity and technical flexibility to update and improve the service on a very frequent basis
 15. made all new source code open, reuseable and published under appropriate licenses (or else provide a convincing explanation of why this cannot be done for specific subsets of the source code)
-16. used open standards and common Government platforms (e.g. Identity Assurance) where available
+16. used open standards and common Government platforms (eg Identity Assurance) where available
 17. an ongoing ability to test the end-to-end service as if it were in an environment identical to that of the live version, with dummy accounts and a representative sample of potential service users, on all common browsers and devices
 18. instrumented analytics tools and ensured that performance data can be collected
 19. built and resourced a service that can be improved daily, ensuring that user feedback and performance data is translated into development

--- a/service-manual/making-software/accessibility-testing.md
+++ b/service-manual/making-software/accessibility-testing.md
@@ -24,10 +24,10 @@ Accessibility testing is very similar to [usability testing](/service-manual/use
 
 It’s important to consider a range of disabilities when you are testing any product or service, including those with;
 
-* cognitive and learning disabilities e.g. dyslexia or attention deficit disorders
-* visual impairments e.g. total and partial blindness, colour blindness, poor vision 
+* cognitive and learning disabilities eg dyslexia or attention deficit disorders
+* visual impairments eg total and partial blindness, colour blindness, poor vision 
 * auditory disabilities which can also affect language 
-* motor skills impairments e.g. those affected by arthritis, strokes, RSI
+* motor skills impairments eg those affected by arthritis, strokes, RSI
 
 Section III of the [Disability Discrimination Act (DDA)](http://www.nidirect.gov.uk/the-disability-discrimination-act-dda), also states that websites should be accessible to blind and disabled users. The Code of Practice for this section of the DDA was published on 27th May 2002. The elements most relevant to website designs are set out in [this blogpost](http://www.webcredible.co.uk/user-friendly-resources/web-accessibility/uk-website-legal-requirements.shtml).
 
@@ -35,11 +35,11 @@ Section III of the [Disability Discrimination Act (DDA)](http://www.nidirect.gov
 
 Most accessibility testing is typically conducted after an accessibility audit has been conducted.
 
-Accessibility testing with participants with a range of needs is best conducted in the participants' own homes. This is because they will often have things set up to suit their individual needs and the whole process is less stressful for them e.g. travel, environment.
+Accessibility testing with participants with a range of needs is best conducted in the participants' own homes. This is because they will often have things set up to suit their individual needs and the whole process is less stressful for them eg travel, environment.
 
 ##When not to use it
 
-It is often difficult to conduct accessibility testing early on in the process of service design. The service must be fairly robust in order for it to be evaluated by people using assistive technologies e.g. a screen reader will read out the contents of a web page so the code needs to be well structured. 
+It is often difficult to conduct accessibility testing early on in the process of service design. The service must be fairly robust in order for it to be evaluated by people using assistive technologies eg a screen reader will read out the contents of a web page so the code needs to be well structured. 
 
 For accessibility testing to be worth doing, real content needs to be in place rather than ‘dummy text’ if it is to be assessed by those with any cognitive or learning difficulties. Interactive elements such as Calls To Action, hyperlinks, forms etc must be in place if motor skills are being assessed.
 
@@ -49,7 +49,7 @@ Full lab-based accessibility testing is not necessary for every project. An acce
 
 Accessibility audits are an alternative to standard accessibility testing. An accessibility audit involves an accessibility expert reviewing the site or service, highlighting all accessibility issues and making recommendations for fixing them. 
 
-They would typically use assistive software used by disabled web users (e.g. a screen reader) to effectively carry out the audit. See the [W3C accessibility guidelines](http://www.w3.org/TR/WCAG/) for further information.
+They would typically use assistive software used by disabled web users (eg a screen reader) to effectively carry out the audit. See the [W3C accessibility guidelines](http://www.w3.org/TR/WCAG/) for further information.
 
 Accessibility audits are cheaper and quicker than accessibility testing but rely primarily on the expertise of the person conducting them.
 
@@ -59,7 +59,7 @@ Disabled participants should be included as part of a wider user testing recruit
 
 ## Cost
 
-This is a harder to reach audience so the cost of doing so can be relatively expensive. Recruitment is best conducted through specialist organisations or agencies e.g. [RNIB](http://www.rnib.org.uk/Pages/Home.aspx), etc
+This is a harder to reach audience so the cost of doing so can be relatively expensive. Recruitment is best conducted through specialist organisations or agencies eg [RNIB](http://www.rnib.org.uk/Pages/Home.aspx), etc
 
 Additional costs can be incurred if these participants are travelling to your testing location and/or require specialist assistance with carers or travel.
 

--- a/service-manual/making-software/apis.md
+++ b/service-manual/making-software/apis.md
@@ -109,7 +109,7 @@ Where content is sensitive, or requires authentication, use encryption (HTTPS) a
 ### Practice service evolution:
 
 - build for [forwards compatibility](http://en.wikipedia.org/wiki/Forward_compatibility) by gracefully handling content that is unexpected (The [robustness principle](http://en.wikipedia.org/wiki/Robustness_principle) &mdash; Postel's Law explains the ability for The Web and Internet to evolve, though you shouldn't ignore protocol errors, corrupted, or invalidly formatted content)
-- preserve [backwards compatibility](http://en.wikipedia.org/wiki/Backward_compatibility) with existing consumers of your API, by sending expected fields and employing sensible default values for missing fields. Eschew changes to the semantics of content, e.g. don't change a `title` field from meaning the title of the page, to the meaning the prefix for a name to the person's job title.
+- preserve [backwards compatibility](http://en.wikipedia.org/wiki/Backward_compatibility) with existing consumers of your API, by sending expected fields and employing sensible default values for missing fields. Eschew changes to the semantics of content, eg don't change a `title` field from meaning the title of the page, to the meaning the prefix for a name to the person's job title.
 
 Where a revolutionary change is unavoidable, communicate a breaking change by changing the URL.
 When changing URIs, continue to honour old consumers, possibly use a [redirection](http://digital.cabinetoffice.gov.uk/2012/10/11/no-link-left-behind/). [Cool URIs don't change](http://www.w3.org/Provider/Style/URI.html).

--- a/service-manual/making-software/cookies.md
+++ b/service-manual/making-software/cookies.md
@@ -46,7 +46,7 @@ On [the cookies page at GOV.UK](https://www.gov.uk/support/cookies) you can see 
 
 ### Storing your approximate location
 
-Some pages on this site provide you with information based on your location. So when you enter your postcode, we save your approximate location to a cookie. This means you don’t have to keep typing your postcode in, and means we’ll always point you towards services that are closest to you e.g. the nearest UK online centre.
+Some pages on this site provide you with information based on your location. So when you enter your postcode, we save your approximate location to a cookie. This means you don’t have to keep typing your postcode in, and means we’ll always point you towards services that are closest to you eg the nearest UK online centre.
 
 <table>
     <tr>
@@ -67,7 +67,7 @@ The [GOV.UK](https://www.gov.uk) cookies policy does not cover 3rd party transac
 
 New and redesigned services will be expected to notify users that cookies are being set beforehand, using a 'sets a cookie' line of text near the action that triggers the cookie (this text should be linked to the appropriate part of the cookie information page). You can see an example of how that works on GOV.UK [here](https://www.gov.uk/dvla-offices).
 
-Where a user can't be notified before the cookie is set (i.e. if it's set when the user first visits the service using implied consent), the service should use a banner similar to that on [GOV.UK](https://www.gov.uk) to inform people that this is the case and link them to the further information.
+Where a user can't be notified before the cookie is set (ie if it's set when the user first visits the service using implied consent), the service should use a banner similar to that on [GOV.UK](https://www.gov.uk) to inform people that this is the case and link them to the further information.
 
 ## Why we do this
 This policy is in line with EU Law and was devised following extensive research during the beta of [GOV.UK](https://www.gov.uk). It follows the [The Privacy and Electronic Communications (EC Directive) (Amendment) Regulations 2011](http://www.legislation.gov.uk/uksi/2011/1208/contents/made) (PECR). You can read more about how we decided this in [this blog post by GDS Developer Dafydd Vaughan](http://digital.cabinetoffice.gov.uk/2012/01/12/cookies-on-the-beta/).

--- a/service-manual/making-software/standalone-apps.md
+++ b/service-manual/making-software/standalone-apps.md
@@ -83,12 +83,12 @@ So-called “Apps” come in several very, very different flavours.
   - Not persistent on device
   - Some device features unavailable (camera, address book)
   - Requires internet connection
-  - Not snappy enough for some complex services (e.g. Spotify, Facebook, Skype)
+  - Not snappy enough for some complex services (eg Spotify, Facebook, Skype)
   - No ‘download and buy’ revenue stream.
 
 ### Hybrid App
   - A small native app which then loads up a bespoke website
-  - So, can use device features (e.g. camera) that Web apps can’t.
+  - So, can use device features (eg camera) that Web apps can’t.
   - Requires a stand-alone website Examples “Bing for Mobile”, Netflix app, LinkedIn app, BBC News app
 
 #### Hybrid App – Pros & Cons
@@ -131,6 +131,6 @@ NOTE: If these conditions are not in place, it is unlikely you'll obtain approva
 
   6. Is there evidence of demand for this app amongst your target users?  If 'yes', please provide supporting  evidence. 
 
-  7. Given the sheer number of apps out there is there evidence to suggest that this app will actually be downloaded? If 'yes', please provide supporting evidence e.g. examples of similar apps that have proven popular with your target audience and evidence of their popularity.
+  7. Given the sheer number of apps out there is there evidence to suggest that this app will actually be downloaded? If 'yes', please provide supporting evidence eg examples of similar apps that have proven popular with your target audience and evidence of their popularity.
 
-  8. Is there evidence of platform penetration amongst your users to justify building an app for the platform you're proposing to do this for? If 'yes', please provide supporting evidence e.g. analytics data that shows proportion of visitors to your content/service that currently access it using relevant devices
+  8. Is there evidence of platform penetration amongst your users to justify building an app for the platform you're proposing to do this for? If 'yes', please provide supporting evidence eg analytics data that shows proportion of visitors to your content/service that currently access it using relevant devices

--- a/service-manual/making-software/testing-in-agile.md
+++ b/service-manual/making-software/testing-in-agile.md
@@ -38,7 +38,7 @@ Service quality isn’t just a testing issue. The quality of a system is defined
 
 ## Fast Feedback
 
-Agile is reliant on fast feedback loops, so that we can actually be agile and change when we need to change. Testing should be about giving that fast feedback, at the time when it is useful. Agile test techniques (e.g. Behaviour driven development, Acceptance test driven development) have their place and we may well use them, but they are not the primary focus of the test approach.
+Agile is reliant on fast feedback loops, so that we can actually be agile and change when we need to change. Testing should be about giving that fast feedback, at the time when it is useful. Agile test techniques (eg Behaviour driven development, Acceptance test driven development) have their place and we may well use them, but they are not the primary focus of the test approach.
 
 ## Tests are an asset of the product
 
@@ -70,7 +70,7 @@ Read the guidance about [testing code](/service-manual/making-software/code-test
 ### Exploratory Testing
 Exploratory testing is a term commonly used to describe unscripted manual testing whereby the tester uses his or her knowledge, experience and intuition to navigate through the software and identify bugs. A scripted test can only ever test a predetermined outcome. Exploratory testing aims to find and test the less obvious outcomes. A good way to think about it is that automated tests prevent bugs whereas exploratory tests find them.  
 
-Exploratory testing is normally time-boxed and has a specific purpose - e.g. 'I will spend x hours exploring y and z aspects of the system (though my explorations may take me elsewhere and it may take more or less time, I’ll use my judgement as I go)'. 
+Exploratory testing is normally time-boxed and has a specific purpose - eg 'I will spend x hours exploring y and z aspects of the system (though my explorations may take me elsewhere and it may take more or less time, I’ll use my judgement as I go)'. 
 
 The term does not imply that the tester has not prepared for the testing. They will have given the testing some detailed planning in advance, thinking for instance about the specific aspects they want to explore, and any data or other system set-up that they will need.  
 

--- a/service-manual/measurement/costpertransaction.md
+++ b/service-manual/measurement/costpertransaction.md
@@ -40,7 +40,7 @@ Where resources (eg call centres) are shared with other services, costs should b
 
 The cost per *digital* transaction is the total cost of providing the digital service divided by the total number of transactions completed digitally, including [assisted digital](/service-manual/assisted-digital) transactions.
 
-Where processes and costs are common to more than one channel (e.g. processing wet signatures for passports, or printing driving licences), they should be apportioned. For example, if half of all transactions are completed digitally, then 50% of the common costs should be apportioned to the digital channel.
+Where processes and costs are common to more than one channel (eg processing wet signatures for passports, or printing driving licences), they should be apportioned. For example, if half of all transactions are completed digitally, then 50% of the common costs should be apportioned to the digital channel.
 
 ## What costs should be included
 
@@ -84,7 +84,7 @@ Having agreed a goal for your digital take-up, the following formula will provid
 
 > CPT=A+((B-A)/(1-X))*(Y-X)
 
-e.g. if the current average CPT is £2 and digital CPT is 50p, and if current digital take-up is 40% and the target is 80%, the target for average CPT would be £1.
+eg if the current average CPT is £2 and digital CPT is 50p, and if current digital take-up is 40% and the target is 80%, the target for average CPT would be £1.
 
 GDS can calculate this for you based on current figures.
 
@@ -104,9 +104,9 @@ This worked example sets out the DVLA methodology used to calculate unit costs, 
 
 The first consideration should be the purpose and use of the cost. An internal recharging model will be more concerned with the direct costs of the service, whereas an external cost recovery model will need to consider overhead apportionment and other forms of contribution.
 
-Once the purpose of the model has been established, appropriate expense heads need to be identified. Consideration needs to be given to the cost type, i.e. whether they are fixed, semi-fixed or variable in nature. Fixed cost elements (as the latter worked example will show) will have the result of reducing unit costs as volumes increase. Purely variable costs are reliant on volume so there is a linear relationship between a pure variable unit cost and the volume of the transaction.
+Once the purpose of the model has been established, appropriate expense heads need to be identified. Consideration needs to be given to the cost type, ie whether they are fixed, semi-fixed or variable in nature. Fixed cost elements (as the latter worked example will show) will have the result of reducing unit costs as volumes increase. Purely variable costs are reliant on volume so there is a linear relationship between a pure variable unit cost and the volume of the transaction.
 
-In many cases, the unit cost is made up of a combination of fixed and variable elements. In the example below the fixed cost elements include expense heads relating to the development of the digital channel; support and maintenance; and salaries (although they are more appropriately classified as semi-fixed). The variable costs that feed into the model include consumables costs, postage and those relating to the intermediary service – i.e. the contracted price per transaction.
+In many cases, the unit cost is made up of a combination of fixed and variable elements. In the example below the fixed cost elements include expense heads relating to the development of the digital channel; support and maintenance; and salaries (although they are more appropriately classified as semi-fixed). The variable costs that feed into the model include consumables costs, postage and those relating to the intermediary service – ie the contracted price per transaction.
 
 In establishing the unit costs of the licensing service via the various channels all relevant costs (as outlined above) are collated to give overall totals and these overall totals are then divided by the actual, or where applicable, the forecast transaction volumes.
 

--- a/service-manual/measurement/performanceframework.md
+++ b/service-manual/measurement/performanceframework.md
@@ -30,7 +30,7 @@ In order to improve the performance of a service, you have to analyse and identi
 
 1. Have you identified who your users are?
 2. Have you articulated your users’ needs?
-3. Have you prioritised services (e.g. by number of users or cost)?
+3. Have you prioritised services (eg by number of users or cost)?
 
 There is typically a hierarchy of interested users, all of whom will have different metrics for success. Technical staff might have operational and optimisation concerns, while senior management and ministers will have more strategic and comparative concerns.These needs will be reflected in the organisation’s business objectives.
 
@@ -72,11 +72,11 @@ Establish a 'baseline' based on current performance trends by channel, against w
 ###Checklist
 
 1. Have you measured your current performance?
-2. Have you compared your performance with similar types of service (e.g. by transaction category)?
+2. Have you compared your performance with similar types of service (eg by transaction category)?
 3. Do you know who your users are in terms of age, disability, socio-economic group and internet usage?
 
 It is good practice to look at performance trends over time, rather than take a snapshot at a particular point in time. Peaks and dips in performance are then measured relative to this base (or trend) line which helps to identify the effect of communications or design initiatives. It also reveals seasonal variations in performance.
-Benchmarking against other services can also provide a useful context for judging performance. By comparing to other similar services (e.g. requesting a license or reporting information) you know whether the service is significantly better or worse than expected. A complete list of the government’s transactional services is available on GOV.UK.
+Benchmarking against other services can also provide a useful context for judging performance. By comparing to other similar services (eg requesting a license or reporting information) you know whether the service is significantly better or worse than expected. A complete list of the government’s transactional services is available on GOV.UK.
 You need to know who your users are to be able to determine whether they are likely to need assisted digital to help them use the digital service. The proportion of users needing assisted digital will vary based on the users of the particular service. For example, a higher proportion of people applying for incapacity benefits are more likely to need assistance with digital services than those needing to pay their road tax.
 
 ##Aggregate data
@@ -98,7 +98,7 @@ Be aware though that combining data from different data sources can lead to huge
 Communicate performance information to your users through the appropriate dashboards, reports and alerts. For the 4 KPIs set out in the digital strategy this will be done through the performance platform. Highlight specific segments that you know users are interested in, and make sure that your visualisations are simple, actionable and contain minimal amounts of chart junk.
 
 ###Checklist
-1. Have you done any segmentation (i.e. analysed performance data by segment)?
+1. Have you done any segmentation (ie analysed performance data by segment)?
 2. Have you designed the appropriate dashboards, reports and alerts?
 3. Are your data visualisations visible to their intended audience?
 4. Have you followed best practice design principles for data visualisation?

--- a/service-manual/measurement/usersatisfaction.md
+++ b/service-manual/measurement/usersatisfaction.md
@@ -82,7 +82,7 @@ An exit survey will be run continuously on your service, and report satisfaction
 
 You should also carry out a more comprehensive user satisfaction survey every six months.
 
-You could consider analysing the key factors driving satisfaction with the service. For example, by asking additional questions (e.g. on ease of use, accuracy, look and feel) you can determine which of those factors is most positively contributing to user satisfaction and hence prioritise where to focus ongoing design efforts.
+You could consider analysing the key factors driving satisfaction with the service. For example, by asking additional questions (eg on ease of use, accuracy, look and feel) you can determine which of those factors is most positively contributing to user satisfaction and hence prioritise where to focus ongoing design efforts.
 
 ## Further reading
 [Survey design](/service-manual/users/user-research/surveydesign.html)

--- a/service-manual/operations/helpdesk.md
+++ b/service-manual/operations/helpdesk.md
@@ -30,7 +30,7 @@ Your planning will be greatly aided by drawing on the traditional contact centre
 
 You’ll need to have some idea of the volume and type of contacts that you will receive for the service you’re supporting. In many cases, you can use historical data for similar services as a baseline. 
 
-This element of your planning will also need to take into account the contact channels you intend to support (e.g., email, phone, chat, Twitter, Facebook, surface mail, etc.). Ideally, each of these channels will have a separate contact forecast to aid your planning. 
+This element of your planning will also need to take into account the contact channels you intend to support (eg email, phone, chat, Twitter, Facebook, surface mail, etc.). Ideally, each of these channels will have a separate contact forecast to aid your planning. 
 
 This portion of your planning will also be informed by or will itself drive decisions about the technology you’ll use to route, handle, and store historical data from these contacts.
 

--- a/service-manual/operations/operating-servicegovuk-subdomains.md
+++ b/service-manual/operations/operating-servicegovuk-subdomains.md
@@ -61,7 +61,7 @@ Service managers should notify the Government Digital Service technical architec
 
 **Usernames and passwords**
 
-If the service is a private alpha or private beta release then it should be protected by a username and password known only to the development team and the users who are testing the service. If a service, or part of a service, is a public alpha or beta releases then it should be clearly marked as such with a text label on every page (i.e. don’t use an image containing the word alpha or beta) and in every API response.
+If the service is a private alpha or private beta release then it should be protected by a username and password known only to the development team and the users who are testing the service. If a service, or part of a service, is a public alpha or beta releases then it should be clearly marked as such with a text label on every page (ie don’t use an image containing the word alpha or beta) and in every API response.
 
 **Multiple environments**
 

--- a/service-manual/the-team/delivery-manager-jd.md
+++ b/service-manual/the-team/delivery-manager-jd.md
@@ -84,7 +84,7 @@ SALARY SCALE:
 The main responsibilities of the post are:
 
 * delivering projects or programmes with a strong understanding of agile and waterfall project management methodologies, change and risk management and the interaction between product development, implementation and support services.
-* assuring all Government Digital Service Products meet the standard build requirements (e.g. functionality, usability, performance, scalability, security, resiliency, etc)
+* assuring all Government Digital Service Products meet the standard build requirements (eg functionality, usability, performance, scalability, security, resiliency, etc)
 * managing tight resource constraints, conflicting priorities and a dynamic programme would be highly beneficial
 * representing the Government Digital Service at senior level by providing governance and leadership to project teams and ensuring contract management support
 * implementing business and cultural change and introducing new process and procedures to ensure business improvements are achieved

--- a/service-manual/the-team/service-manager-jd.md
+++ b/service-manual/the-team/service-manager-jd.md
@@ -168,7 +168,7 @@ Your role will involve managing the product lifecycle - initial design and/or re
 * ensure teams appreciate how market demands, investment decisions and other commercial considerations such as funding and pricing models influence suppliers and the delivery of services
 
 #### Desirable
-* identify and implement different ways of working deployed in other sectors e.g. using resources, assets and commercial arrangements
+* identify and implement different ways of working deployed in other sectors eg using resources, assets and commercial arrangements
 * develop and apply market and economic understanding and insights, working with commercial experts, to support sound commercial decision-making and recommendations
 * take a wide view, successfully achieving common goals with organisations that have different priorities
 

--- a/service-manual/the-team/working-with-specialists.md
+++ b/service-manual/the-team/working-with-specialists.md
@@ -29,7 +29,7 @@ Trust domain experts to define what you need to be looking for. Developers and d
 
 If you know particular individuals are the best fit for a particular skill then there’s nothing wrong with hiring them. GDS are happy to provide advice on a prospective candidate too. Equally there’s nothing wrong with using a recruitment specialist to get the candidate you need. Remember that the service will be judged on what it delivers, so you must have confidence that the specialists you recruit are the right people to deliver that work.
 
-GDS can also provide support to departments to assist them during their procurements for Digital / Agile services, whether this is using existing purchasing frameworks / tools (e.g. G-Cloud, Spot-Buy, etc) in advance of the Digital Procurement Framework being available, or following its go-live. This support could include early-stage supplier engagement in the form of hack days, proof of concepts, prototypes, etc, either in advance of, or as a first-stage evaluation for, a formal procurement.
+GDS can also provide support to departments to assist them during their procurements for Digital / Agile services, whether this is using existing purchasing frameworks / tools (eg G-Cloud, Spot-Buy, etc) in advance of the Digital Procurement Framework being available, or following its go-live. This support could include early-stage supplier engagement in the form of hack days, proof of concepts, prototypes, etc, either in advance of, or as a first-stage evaluation for, a formal procurement.
 
 
 ## Proposed Digital Procurement Framework
@@ -38,7 +38,7 @@ The Digital Procurement Framework is being designed by the Government Digital Se
 
 ### How will it work?
 
-GDS will ensure there’s a sufficient supply of companies able to deliver digital capability where government does business. The list of suppliers available on the framework will be refreshed periodically (e.g. every 4 to 5 months) as technology and the market moves.
+GDS will ensure there’s a sufficient supply of companies able to deliver digital capability where government does business. The list of suppliers available on the framework will be refreshed periodically (eg every 4 to 5 months) as technology and the market moves.
 
 We want to provide an online portal that enables departments to buy digital/agile services from the suppliers on the Digital Procurement Framework, and are currently looking at utilising the platform that GDS is building for the G-Cloud team, ideally leading to a single point of entry for buyers and suppliers alike.
 

--- a/service-manual/users/card-sorting.md
+++ b/service-manual/users/card-sorting.md
@@ -39,7 +39,7 @@ Open card sorts are most suitable for identifying how users think about informat
 
 ##Weaknesses/when not to use
 
-The analysis of card sorting can be difficult if no clear categories emerge. It can also be difficult to conduct a card sort on a very large website with a broad scope of content (e.g. GOV.UK) since the maximum number of cards may not be representative of all of the content.
+The analysis of card sorting can be difficult if no clear categories emerge. It can also be difficult to conduct a card sort on a very large website with a broad scope of content (eg GOV.UK) since the maximum number of cards may not be representative of all of the content.
 
 ## Online tools
 

--- a/service-manual/users/introduction-to-user-research.md
+++ b/service-manual/users/introduction-to-user-research.md
@@ -33,7 +33,7 @@ Qualitative techniques are intensive, and often small scale. These include focus
 
 Quantitative techniques involve higher-volume research, and include online surveys, face-to-face interviews, and involve a structured approach to data collection and analysis. 
 
-Product based research can be conducted in-house or via a specialist agency. In-house approaches can be quicker as they involve less lead time (e.g. procurement), but require skilled in-house researchers, and can involve the procurement of some specialist software. Typically agencies are only used when specialist skills/experience is required that is not available in-house, and/or the scale of the project would mean it is difficult to provide dedicated internal resource. 
+Product based research can be conducted in-house or via a specialist agency. In-house approaches can be quicker as they involve less lead time (eg procurement), but require skilled in-house researchers, and can involve the procurement of some specialist software. Typically agencies are only used when specialist skills/experience is required that is not available in-house, and/or the scale of the project would mean it is difficult to provide dedicated internal resource. 
 
 ## Strategic research
 

--- a/service-manual/users/user-research/focusgroupsminigroupsandinterviews.md
+++ b/service-manual/users/user-research/focusgroupsminigroupsandinterviews.md
@@ -29,7 +29,7 @@ Focus groups, mini groups, and 1:1 interviews involve unstructured interviews or
  
 A focus group is normally comprised of 6-12 people, although sometimes mini groups are favoured (4-5 people) as they can lead to a greater depth of discussion. 1:1 interviews are conducted by a moderator with a single respondent, sometimes these are conducted over the phone (telephone depths).
  
-Interviews and discussion groups are both facilitated by a trained moderator using a specially designed topic guide in order to ensure the discussion is focused and keeps on topic. Sessions normally last 1-2 hours and will often involve participants being shown stimulus – e.g. communications materials to inform discussion, and sessions may include interactive techniques e.g. role play scenarios.
+Interviews and discussion groups are both facilitated by a trained moderator using a specially designed topic guide in order to ensure the discussion is focused and keeps on topic. Sessions normally last 1-2 hours and will often involve participants being shown stimulus – eg communications materials to inform discussion, and sessions may include interactive techniques eg role play scenarios.
  
 ##Where / how you might use it
  

--- a/service-manual/users/user-research/guerillatesting.md
+++ b/service-manual/users/user-research/guerillatesting.md
@@ -26,7 +26,7 @@ breadcrumbs:
 This guidance talks about how Guerilla testing can be used to provide user research that can feed into product and service design.
 
 ##Guidance
-Guerilla user testing is a low cost method of user testing. The term ‘guerilla’ refers to its ‘out in the wild’ style, in the fact that it can be conducted anywhere e.g. cafe, library, train station etc, essentially anywhere where there is significant footfall.
+Guerilla user testing is a low cost method of user testing. The term ‘guerilla’ refers to its ‘out in the wild’ style, in the fact that it can be conducted anywhere eg cafe, library, train station etc, essentially anywhere where there is significant footfall.
 
 Guerilla testing works well to quickly validate how effective a design is on its intended audience, whether certain functionality works in the way it is supposed to, or even establishing whether a brand or proposition is clear.
 
@@ -44,7 +44,7 @@ There are a few logistics that should be taken into consideration before conduct
 
 * General: always ask permission first to speak with people, outline briefly the purpose of the research and reassure them about confidentiality
 * Scope: keep it simple and quick
-* Location: consider the location and set up carefully e.g. a busy train station may have the footfall but people might be in too much of a hurry to spare the time
+* Location: consider the location and set up carefully eg a busy train station may have the footfall but people might be in too much of a hurry to spare the time
 * Equipment: for website evaluations, Silverback is an ‘easy to use’ software solution that enables screen capturing and recording. However, whenever recording sessions you must seek permission from the participant first. Provide them with a written consent form for them to sign.
 * Incentives: providing incentives for audience participation is not required or necessary. However, depending on where you are running your sessions chocolates are always a welcome ‘thank you’ for peoples’ time.
 

--- a/service-manual/users/user-research/labbasedusertesting.md
+++ b/service-manual/users/user-research/labbasedusertesting.md
@@ -33,7 +33,7 @@ From a traditional perspective, user testing measures how well participants resp
 
 A product or service is usually assessed by asking small samples of the ‘target audience, in one to one sessions, to complete specific but realistic tasks. The facilitator observes how well the participants are able to complete those tasks, noting down the areas or features that cause the participant problems. Often the facilitator will ask participants to think aloud whilst completing those tasks in order to understand their decision processes better.
 
-User testing can be conducted on low-fi assets e.g. paper prototypes, wireframes and hi-fi assets e.g. html/css prototypes, live digital services. It’s most effective when conducted early within the lifecycle of a product but can be conducted towards the end of the service lifecycle to validate any usability improvements.
+User testing can be conducted on low-fi assets eg paper prototypes, wireframes and hi-fi assets eg html/css prototypes, live digital services. It’s most effective when conducted early within the lifecycle of a product but can be conducted towards the end of the service lifecycle to validate any usability improvements.
 
 ##Where/how you might use it
 
@@ -45,7 +45,7 @@ Usability testing is best suited to finding the big issues, essentially the prob
 
 The lab environment may also be considered a weakness. It means testing is conducted in a very different space to that a user will commonly be in.
 
-This method is not an appropriate for understanding user behaviour or user needs e.g. what they might want from a product / service. 
+This method is not an appropriate for understanding user behaviour or user needs eg what they might want from a product / service. 
 
 ##No./Types of participants
 
@@ -53,7 +53,7 @@ Between 5-8 participants, per round of user testing is sufficient to highlight t
 
 ##Cost
 
-Costs will vary according to your target audience e.g. niche expertise, hard to reach etc.
+Costs will vary according to your target audience eg niche expertise, hard to reach etc.
 The easiest way to recruit participants is to use a market research recruitment agency. Expect to pay from £150-£200 per recruit (includes finders fee and cash incentive).
 
 Lab hire per day varies depending on location and facilities. Expect to pay between £800-£1200 per day.

--- a/service-manual/users/user-research/remoteusability.md
+++ b/service-manual/users/user-research/remoteusability.md
@@ -38,7 +38,7 @@ Each session usually includes tasks being given to see how users interact with t
 
 ##Where/how you might use it
  
-Remote usability testing can be used to test both website content, and online services. Testing content normally involves people completing task based on the online content, while online services are normally tested by asking users to complete a task using the online tool or transaction e.g. Jobseekers Allowance, Driving Licence etc. Success is measured on whether the user can complete the tasks/transaction. Benchmarks on new and existing products are gathered so that completion rates (and other success measures) be collected and performance monitored.
+Remote usability testing can be used to test both website content, and online services. Testing content normally involves people completing task based on the online content, while online services are normally tested by asking users to complete a task using the online tool or transaction eg Jobseekers Allowance, Driving Licence etc. Success is measured on whether the user can complete the tasks/transaction. Benchmarks on new and existing products are gathered so that completion rates (and other success measures) be collected and performance monitored.
 
 The key advantage of remote usability testing are the following:
 

--- a/service-manual/users/user-research/sentimentanalysis.md
+++ b/service-manual/users/user-research/sentimentanalysis.md
@@ -37,4 +37,4 @@ This is a notoriously difficult technique for anything beyond broad statements, 
 
 ##Sample 
 
-Feedback can be gathered from any user feedback point e.g. email, website, survey.
+Feedback can be gathered from any user feedback point eg email, website, survey.

--- a/service-manual/users/user-research/surveydesign.md
+++ b/service-manual/users/user-research/surveydesign.md
@@ -27,16 +27,16 @@ The abundance of free survey tools makes it cheap and easy for user research tea
 
 ##Guidance
  
-In order to increase the effectiveness of the survey it is important to include an introduction that explains the purpose of the survey to potential respondents, and also provide some reasons that will make them want to take part e.g. the results will be published, their feedback will help improve the website etc. As it’s unlikely that it will be possible to include monetary incentives, it’s important the introduction is worded in a manner that increases the likelihood that people will want to take part. It is also recommended that people are informed of how long the survey will take to complete as this will reduce drop out rate (people who start the survey but don’t finish).
+In order to increase the effectiveness of the survey it is important to include an introduction that explains the purpose of the survey to potential respondents, and also provide some reasons that will make them want to take part eg the results will be published, their feedback will help improve the website etc. As it’s unlikely that it will be possible to include monetary incentives, it’s important the introduction is worded in a manner that increases the likelihood that people will want to take part. It is also recommended that people are informed of how long the survey will take to complete as this will reduce drop out rate (people who start the survey but don’t finish).
  
 **Questions**
  
-Screener questions should be placed at the beginning of surveys to ensure that the correct people take the survey e.g. demographic information, reason for visiting etc. Quotas may also be set so that you can control the number of people taking the survey that fall into a specific demographic group or audience type. A typical user survey will be structured in the following manner:
+Screener questions should be placed at the beginning of surveys to ensure that the correct people take the survey eg demographic information, reason for visiting etc. Quotas may also be set so that you can control the number of people taking the survey that fall into a specific demographic group or audience type. A typical user survey will be structured in the following manner:
  
 * Introduction – purpose of the survey, why it’s important that people take part.
-* Screener questions – questions that ensure the correct people complete the survey e.g. demographic, reasons for visiting
-* KPI questions – [questions that benchmark performance](https://www.gov.uk/service-manual/measurement/index.html) e.g. satisfaction, recommendation.
-* Follow up demographic questions – additional respondent information e.g. working/not working, salary, location etc
+* Screener questions – questions that ensure the correct people complete the survey eg demographic, reasons for visiting
+* KPI questions – [questions that benchmark performance](https://www.gov.uk/service-manual/measurement/index.html) eg satisfaction, recommendation.
+* Follow up demographic questions – additional respondent information eg working/not working, salary, location etc
  
 **Common survey question types**
  
@@ -44,7 +44,7 @@ Surveys are normally composed of the following types of questions:
  
 **Single response** (these type of questions allow the respondent to select just one answer)
  
-e.g.
+eg:
  
 Q. What is your gender?
  
@@ -54,7 +54,7 @@ Q. What is your gender?
  
 **Multiple choice questions** (respondents can select more than one answer)
  
-e.g.
+eg:
  
 Q. Why did you visit more than one area of the site today (please tick all that apply)?
  

--- a/service-manual/users/user-research/userresearchbriefs.md
+++ b/service-manual/users/user-research/userresearchbriefs.md
@@ -41,7 +41,7 @@ A Research brief should contain the following information:
 
 * **Cost** - this section should state the budget available for the research. It is suggested that research agencies should be asked to provide a range of price options, so that insight teams can choose the most appropriate approach for their needs.
 
-* **Deliverables** - this should outline how the research is to be delivered e.g. presentation, workshop etc.
+* **Deliverables** - this should outline how the research is to be delivered eg presentation, workshop etc.
 
 * **Timings** - this should specify when the research is to be delivered.
 

--- a/service-manual/users/user-research/userresearchsurveys.md
+++ b/service-manual/users/user-research/userresearchsurveys.md
@@ -34,16 +34,16 @@ Surveys can be conducted either face to face by a trained moderator or through s
 A range of survey methods and delivery channels are available including:
  
 
-* Online web surveys – self-completion surveys used to obtain information from web users. Surveys are activated when a user interacts with a page – this can either be through arriving/leaving a page, or clicking on a link. A piece of computer script is used to control the frequency at which users are invited to take part in a survey e.g. 1:n users will get invited to take a specific survey. In order to increase completion rates, online surveys are normally no longer than 5-10 mins in length (approximately 20 – 25 questions). 
-* Email survey – these are identical in set up and design to online web surveys, except participants are asked to complete them via an email, and not at random when they visit a website. Email surveys are often more targeted as participants can be identified by information already known about the them e.g. demographic, information usage etc.
+* Online web surveys – self-completion surveys used to obtain information from web users. Surveys are activated when a user interacts with a page – this can either be through arriving/leaving a page, or clicking on a link. A piece of computer script is used to control the frequency at which users are invited to take part in a survey eg 1:n users will get invited to take a specific survey. In order to increase completion rates, online surveys are normally no longer than 5-10 mins in length (approximately 20 – 25 questions). 
+* Email survey – these are identical in set up and design to online web surveys, except participants are asked to complete them via an email, and not at random when they visit a website. Email surveys are often more targeted as participants can be identified by information already known about the them eg demographic, information usage etc.
 * Telephone interviews – structured interviews that are conducted over the phone by a trained moderator.
-* Face to face interviews – like telephone interviews, face to face interviews are structured and conducted by a trained moderator. Unlike other survey methods, respondents may be shown limited stimulus – e.g. advert, leaflet cover. website design etc. Face to face interviews also enable researchers to target respondents more easily by demographic, geographic and socio economic group.
+* Face to face interviews – like telephone interviews, face to face interviews are structured and conducted by a trained moderator. Unlike other survey methods, respondents may be shown limited stimulus – eg advert, leaflet cover. website design etc. Face to face interviews also enable researchers to target respondents more easily by demographic, geographic and socio economic group.
  
 ##Where/how you might use it
  
-Surveys can be a relatively cheap and quick way of gathering and quantifying public opinion and monitoring change over time. Online/email surveys are normally the cheapest method as these can be conducted in-house using inexpensive/free survey software, inviting people to take part from their own website, or using a database of email addresses. Although sometimes a small cost may be incurred if an incentive is used (e.g. competition to win vouchers etc.). Telephone and face interviews are the most costly methodology and they are normally conducted via a third party agency. Cost can, however be kept down by conducting interviews as part of an Omnibus survey which involves questions from a variety of subjects (from a number of clients) being asked during the same interview, as well as the demographic information on each respondent. Omnibus surveys can be conducted online, telephone, and face to face.
+Surveys can be a relatively cheap and quick way of gathering and quantifying public opinion and monitoring change over time. Online/email surveys are normally the cheapest method as these can be conducted in-house using inexpensive/free survey software, inviting people to take part from their own website, or using a database of email addresses. Although sometimes a small cost may be incurred if an incentive is used (eg competition to win vouchers etc.). Telephone and face interviews are the most costly methodology and they are normally conducted via a third party agency. Cost can, however be kept down by conducting interviews as part of an Omnibus survey which involves questions from a variety of subjects (from a number of clients) being asked during the same interview, as well as the demographic information on each respondent. Omnibus surveys can be conducted online, telephone, and face to face.
  
-Surveys can be used to size a market to find out how many people own a product, or take part in an activity e.g. how many people use the Internet in the UK. They can be also used to understand usage and attitudes towards a product or activity e.g. how often people use the Internet, how they access it, why the use it etc. Complex analysis can be also be conducted to understand key drivers of attitude/behaviour, segmentation of audiences, and trade offs between different opinions etc.
+Surveys can be used to size a market to find out how many people own a product, or take part in an activity eg how many people use the Internet in the UK. They can be also used to understand usage and attitudes towards a product or activity eg how often people use the Internet, how they access it, why the use it etc. Complex analysis can be also be conducted to understand key drivers of attitude/behaviour, segmentation of audiences, and trade offs between different opinions etc.
  
 Surveys provide a snapshot of opinion, and are a useful method for monitoring uptake, usage and attitudes over time.
  
@@ -53,7 +53,7 @@ Although surveys can be a quick and cheap manner in which to conduct user resear
  
 * Normally don’t allow much time or context for considered replies.
 * Questions can be misunderstood – surveys need to be designed carefully to avoid this.
-* Completion bias – one common criticism of some types of surveys is that they are only completed by people who have something to say e.g. are either very satisfied or very dissatisfied. This can be overcome via face to face interviews and / or sophisticated sampling techniques, although this is normally expensive. 
+* Completion bias – one common criticism of some types of surveys is that they are only completed by people who have something to say eg are either very satisfied or very dissatisfied. This can be overcome via face to face interviews and / or sophisticated sampling techniques, although this is normally expensive. 
  
 ##Participants
  
@@ -61,7 +61,7 @@ All surveys, regardless of methodology should use a robust sample that is nation
  
 It is important that the delivery channel used considers the target audience. For example in the recent Digital Landscape research an online and face-to-face methodology was used as online and offline audiences needed to be interviewed - an online only methodology would have excluded those who are offline, and the opinions on this audience omitted from the research
  
-It is also important to note that reaching hard-to-reach groups can be more time consuming and costly (e.g. BME, people with disabilities).
+It is also important to note that reaching hard-to-reach groups can be more time consuming and costly (eg BME, people with disabilities).
  
 ##Cost
  


### PR DESCRIPTION
As per the [styleguide](https://www.gov.uk/designprinciples/styleguide#eg-etc-ie) we should not put fullstops after or between these notations
