### PR TITLE
assume less context in service.gov.uk intro

### DIFF
--- a/service-manual/operations/operating-servicegovuk-subdomains.md
+++ b/service-manual/operations/operating-servicegovuk-subdomains.md
@@ -17,7 +17,7 @@ breadcrumbs:
     url: /service-manual/operations
 ---
 
-Government offers a number of different digital services to citizens. Each service should be made available through the single government domain GOV.UK. However, as each service may have separate hosting requirements, it may need a separate domain. This page describes the use of `service.gov.uk` subdomains for hosting digital services.
+Government offers a number of different digital services to citizens. While the start and end of a user's journey will be on GOV.UK, the service itself will typically be hosted elsewhere, and will need a different domain name as a result. This page describes the use of `service.gov.uk` subdomains for hosting digital services.
 
 > Note: This document is written as a "standard," and as such uses the words MUST, SHOULD, MAY and MUST NOT as defined in [RFC 2119](http://www.ietf.org/rfc/rfc2119.txt).
 


### PR DESCRIPTION
The introduction to the service.gov.uk page assumes context on the part of the reader about what kind of services we're talking about, and why they might live on service.gov.uk subdomains. This is an attempt to provide that context, but as I'm not sure I understand it myself, I'd appreciate feedback on this -- particularly from @jystewart, @garethr and @ejhp.
