### PR TITLE
Reworked/more explicit guidance on use of cookies

### DIFF
--- a/service-manual/making-software/cookies.md
+++ b/service-manual/making-software/cookies.md
@@ -44,7 +44,7 @@ Responsibility for complying with these regulations lies with the website operat
 
 This guide covers how to use cookies on government services, but the principles also apply to other technologies such as HTML5 local storage.
 
-** You should minimise the use of cookies on services, store as little information as you require for as short a time as necessary to deliver a good service to users. **
+**You should minimise the use of cookies on services, store as little information as you require for as short a time as necessary to deliver a good service to users.**
 
 If your service requires cookies to be stored then you need to ensure that they can be explained simply and clearly, in a way that the majority of users can understand.
 


### PR DESCRIPTION
Include information about different types of cookies and their intrusiveness. Add rules on what information must be published about cookies and how to notify users about them.

This change adds some new rules for services that should probably be reviewed more widely before merging such as:
- services should include their own cookie information page (with links back to the GOV.UK edition)
- services should notify users about cookies using the blue banner style notice (even if GOV.UK has notified users already) because the cookies are likely to be different to those on GOV.UK.
