### PR TITLE
hgroup is no longer valid

### DIFF
--- a/_layouts/browse.html
+++ b/_layouts/browse.html
@@ -5,12 +5,12 @@ section_class: browse
 
 <article role="article" class="group">
   <header class="page-header group">
-    <hgroup>
+    <div class="hgroup">
       <h1>{{ page.title }}</h1>
       {% if page.subtitle %}
       <h2 class="subtitle">{{ page.subtitle }}</h2>
       {% endif %}
-    </hgroup>
+    </div>
   </header>
 
   {{ content }}

--- a/_layouts/category-index.html
+++ b/_layouts/category-index.html
@@ -6,12 +6,12 @@ section_class: category-index
 
 <article role="article" class="group">
   <header class="page-header group">
-    <hgroup>
+    <div class="hgroup">
       <h1>{{ page.title }}</h1>
       {% if page.subtitle %}
       <h2 class="subtitle">{{ page.subtitle }}</h2>
       {% endif %}
-    </hgroup>
+    </div>
 
     {% include _meta-phases.html %}
   </header>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,12 +7,12 @@ section_class: default
 
 <article role="article" class="group">
   <header class="page-header group">
-    <hgroup>
+    <div class="hgroup">
       <h1>{{ page.title }}</h1>
       {% if page.subtitle %}
       <h2 class="subtitle">{{ page.subtitle }}</h2>
       {% endif %}
-    </hgroup>
+    </div>
   </header>
 
   <div class="article-container group">

--- a/_layouts/design-patterns.html
+++ b/_layouts/design-patterns.html
@@ -5,12 +5,12 @@ section_class: wide design-patterns
 
 <article role="article" class="group">
   <header class="page-header group">
-    <hgroup>
+    <div class="hgroup">
       <h1>{{ page.title }}</h1>
       {% if page.subtitle %}
       <h2 class="subtitle">{{ page.subtitle }}</h2>
       {% endif %}
-    </hgroup>
+    </div>
   </header>
 
   <div class="article-container group">

--- a/_layouts/detailed-guidance.html
+++ b/_layouts/detailed-guidance.html
@@ -6,12 +6,12 @@ section_class: detailed-guidance
 
 <article role="article" class="group">
   <header class="page-header group">
-    <hgroup>
+    <div class="hgroup">
       <h1>{{ page.title }}</h1>
       {% if page.subtitle %}
       <h2 class="subtitle">{{ page.subtitle }}</h2>
       {% endif %}
-    </hgroup>
+    </div>
 
     {% include _meta-phases.html %}
   </header>

--- a/_layouts/gsdm-design-patterns.html
+++ b/_layouts/gsdm-design-patterns.html
@@ -36,7 +36,7 @@
                 <a href="/handbook/43/">Design patterns</a>
               </li>
             </div>
-        <hgroup><h1>{{ page.title }}</h1></hgroup></header><div class="article-container group">
+        <div class="hgroup"><h1>{{ page.title }}</h1></div></header><div class="article-container group">
         <article role="article" class="group">
           <div class="inner">
               {{ content }}

--- a/_layouts/phases-index.html
+++ b/_layouts/phases-index.html
@@ -7,12 +7,12 @@ section_class: phases
 
 <article role="article" class="group">
   <header class="page-header group">
-    <hgroup>
+    <div class="hgroup">
       <h1>{{ page.title }}</h1>
       {% if page.subtitle %}
       <h2 class="subtitle">{{ page.subtitle }}</h2>
       {% endif %}
-    </hgroup>
+    </div>
   </header>
 
   <div class="article-container group">

--- a/_layouts/role-index-content-designer.html
+++ b/_layouts/role-index-content-designer.html
@@ -4,12 +4,12 @@ section_class: wide role-index
 ---
 
 <header class="page-header group">
-  <hgroup>
+  <div class="hgroup">
     <h1{% if page.long-title %} class="long-title"{% endif %}>{{ page.title }}</h1>
     {% if page.subtitle %}
     <h2 class="subtitle">{{ page.subtitle }}</h2>
     {% endif %}
-  </hgroup>
+  </div>
 </header>
 
 {% assign hero = false %}
@@ -34,7 +34,7 @@ section_class: wide role-index
       <ul>
       {% sorted_for p in site.pages sort_by:title %}
         {% if p.audience.primary contains page.audience and (p.type == 'guide' or p.type == 'resource') and p.title != page.hero %}
-        <li> 
+        <li>
             <a href="{{ p.url }}">{{ p.title }}</a>
         </li>
         {% endif %}
@@ -50,7 +50,7 @@ section_class: wide role-index
     <ul>
     {% sorted_for p in site.pages sort_by:title %}
       {% if p.audience.secondary contains page.audience %}
-      <li> 
+      <li>
           <a href="{{ p.url }}" title="{{ p.subtitle }}">{{ p.title }}</a>
           <span class="subtitle">{{ p.subtitle }}</span>
       </li>

--- a/_layouts/role-index-designers.html
+++ b/_layouts/role-index-designers.html
@@ -4,12 +4,12 @@ section_class: wide role-index
 ---
 
 <header class="page-header group">
-  <hgroup>
+  <div class="hgroup">
     <h1{% if page.long-title %} class="long-title"{% endif %}>{{ page.title }}</h1>
     {% if page.subtitle %}
     <h2 class="subtitle">{{ page.subtitle }}</h2>
     {% endif %}
-  </hgroup>
+  </div>
 </header>
 
 {% assign hero = false %}
@@ -34,7 +34,7 @@ section_class: wide role-index
       <ul>
       {% sorted_for p in site.pages sort_by:title %}
         {% if p.audience.primary contains page.audience and (p.type == 'guide' or p.type == 'resource') and p.title != page.hero %}
-        <li> 
+        <li>
             <a href="{{ p.url }}">{{ p.title }}</a>
         </li>
         {% endif %}
@@ -47,11 +47,11 @@ section_class: wide role-index
 
   <div class="link-list more-guides">
     <h3>More guides from the manual</h3>
-  
+
     <ul>
     {% sorted_for p in site.pages sort_by:title %}
       {% if p.audience.secondary contains page.audience %}
-      <li> 
+      <li>
           <a href="{{ p.url }}" title="{{ p.subtitle }}">{{ p.title }}</a>
           <span class="subtitle">{{ p.subtitle }}</span>
       </li>

--- a/_layouts/role-index.html
+++ b/_layouts/role-index.html
@@ -4,12 +4,12 @@ section_class: wide role-index
 ---
 
 <header class="page-header group">
-  <hgroup>
+  <div class="hgroup">
     <h1{% if page.long-title %} class="long-title"{% endif %}>{{ page.title }}</h1>
     {% if page.subtitle %}
     <h2 class="subtitle">{{ page.subtitle }}</h2>
     {% endif %}
-  </hgroup>
+  </div>
 </header>
 
 {% assign hero = false %}
@@ -39,7 +39,7 @@ section_class: wide role-index
       <ul>
       {% sorted_for p in site.pages sort_by:title %}
         {% if p.audience.primary contains page.audience and (p.type == 'guide' or p.type == 'resource') and p.title != page.hero %}
-        <li> 
+        <li>
             <a href="{{ p.url }}">{{ p.title }}</a>
         </li>
         {% endif %}
@@ -52,11 +52,11 @@ section_class: wide role-index
 
   <div class="link-list more-guides">
     <h3>More guides from the manual</h3>
-  
+
     <ul>
     {% sorted_for p in site.pages sort_by:title %}
       {% if p.audience.secondary contains page.audience %}
-      <li> 
+      <li>
           <a href="{{ p.url }}" title="{{ p.subtitle }}">{{ p.title }}</a>
           <span class="subtitle">{{ p.subtitle }}</span>
       </li>

--- a/_layouts/standard-support.html
+++ b/_layouts/standard-support.html
@@ -6,12 +6,12 @@ section_class: detailed-guidance
 
 <article role="article" class="group">
   <header class="page-header group">
-    <hgroup>
+    <div class="hgroup">
       <h1>{{ page.title }}</h1>
       {% if page.subtitle %}
       <h2 class="subtitle">{{ page.subtitle }}</h2>
       {% endif %}
-    </hgroup>
+    </div>
 
     {% include _meta-phases.html %}
   </header>

--- a/_layouts/standard.html
+++ b/_layouts/standard.html
@@ -6,9 +6,9 @@ section_class: dbd
 
 <article role="article" class="group">
   <header class="page-header group">
-    <hgroup>
+    <div class="hgroup">
       <h1>{{ page.title }}</h1>
-    </hgroup>
+    </div>
   </header>
 
   <div class="article-container group">

--- a/_layouts/wide.html
+++ b/_layouts/wide.html
@@ -5,12 +5,12 @@ section_class: wide
 
 <article role="article" class="group">
   <header class="page-header group">
-    <hgroup>
+    <div class="hgroup">
       <h1>{{ page.title }}</h1>
       {% if page.subtitle %}
       <h2 class="subtitle">{{ page.subtitle }}</h2>
       {% endif %}
-    </hgroup>
+    </div>
   </header>
 
   <div class="article-container group">

--- a/service-manual/assets/stylesheets/helpers/_page-header.scss
+++ b/service-manual/assets/stylesheets/helpers/_page-header.scss
@@ -7,7 +7,7 @@ header.page-header {
     margin: 1em 2em 3em 2em;
   }
 
-  hgroup {
+  .hgroup {
     padding: 0;
 
     h1 {

--- a/service-manual/assets/stylesheets/layouts/_gsdm.scss
+++ b/service-manual/assets/stylesheets/layouts/_gsdm.scss
@@ -38,7 +38,7 @@ body {
 }
 
 header.page-header {
-  hgroup {
+  .hgroup {
     background-color: transparent;
   }
 }

--- a/service-manual/assets/stylesheets/views/_home-page.scss
+++ b/service-manual/assets/stylesheets/views/_home-page.scss
@@ -7,20 +7,20 @@
     border: none;
     padding: 0;
 
-    hgroup {
+    .hgroup {
       padding: 0;
-    }    
+    }
   }
 
   .dbd-promo {
     border-bottom: 5px solid $main-colour;
-    overflow: hidden;  
+    overflow: hidden;
     margin: 2em 1em;
 
     @include media(desktop) {
       margin: 0.5em 2em 2em 2em;
     }
-    
+
     p {
       margin: 1em 0;
       float: left;
@@ -31,7 +31,7 @@
         width: 44%;
       }
     }
-    
+
     .logo {
       display: block;
       padding: 0;
@@ -117,7 +117,7 @@
 
   .service-life {
     margin: 0;
-    
+
     h2 {
       margin-top: 0;
       // @include bold-36;

--- a/service-manual/assets/stylesheets/views/_standard.scss
+++ b/service-manual/assets/stylesheets/views/_standard.scss
@@ -30,7 +30,7 @@
       margin: 0 auto;
     }
 
-    hgroup {
+    .hgroup {
       margin: 0 1em;
 
       @include media(tablet) {
@@ -72,7 +72,7 @@
       width: 67%;
       margin: 0 auto;
     }
-    
+
     img{
       margin-bottom: 1.5em;
       @if $is-print == false {
@@ -91,7 +91,7 @@
     @if $is-print == true {
       .common-questions{
         display: none;
-      }      
+      }
     }
 
     ul {
@@ -172,14 +172,14 @@
         orphans: 0;
 
         width: 86%;
-        @include media(desktop) {        
+        @include media(desktop) {
           float: left;
         }
-        @include media(mobile) {   
+        @include media(mobile) {
           padding-left: 15%;
         }
       }
-      
+
     }
 
     .guidance {
@@ -232,7 +232,7 @@
 
 
   @if $is-print == true {
-      a { 
+      a {
         text-decoration: none;
       }
       a:after {

--- a/service-manual/index.html
+++ b/service-manual/index.html
@@ -14,10 +14,10 @@ category: home
 </div>
 
 <header class="page-header group">
-  <hgroup>
+  <div class="hgroup">
     <h1>Government Service Design Manual</h1>
     <h2 class="subtitle">Build services so good that people prefer to use them</h2>
-  </hgroup>
+  </div>
 </header>
 
 <div class="homepage-column">


### PR DESCRIPTION
The hgroup tag has been removed from the html 5 draft specification[1].

For the meantime we'll use a div with class of "hgroup", may refactor in the future.

[1] http://lists.w3.org/Archives/Public/public-html-admin/2013Apr/0003.html
