### PR TITLE
Add advice on credential strength to logins page

### DIFF
--- a/service-manual/making-software/logins.md
+++ b/service-manual/making-software/logins.md
@@ -67,3 +67,4 @@ The ELMS license application system on Business Link required a login to complet
 
 * [Wikipedia on Password policies](http://en.wikipedia.org/wiki/Password_policy#Password_length_and_formation)
 * [CESG Good Practice Guide 44: authentication credentials in support of HMG online services](https://www.gov.uk/government/publications/identity-assurance-enabling-trusted-transactions)
+* [xkcd cartoon explaining password vs. passphrase](https://xkcd.com/936/)


### PR DESCRIPTION
Where new services are creating login systems (those that launch before IDA is ready) need to be requiring strong credentials. 
