### PR TITLE
Test whether css files are compiled

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -18,6 +18,18 @@ if [ -d $GUIDANCE_PATH ]; then
 fi
 
 bundle exec jekyll ./_site
+
+# Jekyll will fail to compile the Sass files if the frontend toolkit isn't checked out
+# however Jekyll doesn't exit with a helpful error, so the build doesn't fail.
+function check_css_compiled {
+    test -f $1 || echo "ERROR: $1 not compiled, Sass compilation above probably failed." && exit 1
+}
+check_css_compiled ./_site/service-manual/assets/stylesheets/main.css
+check_css_compiled ./_site/service-manual/assets/stylesheets/print.css
+check_css_compiled ./_site/service-manual/assets/stylesheets/main-ie6.css
+check_css_compiled ./_site/service-manual/assets/stylesheets/main-ie7.css
+check_css_compiled ./_site/service-manual/assets/stylesheets/main-ie8.css
+
 cp -R ./_site/service-manual $GUIDANCE_PATH
 mv ./.search-index.json $SEARCH_CONTENT_PATH/service-manual.json
 


### PR DESCRIPTION
Jekyll will fail to compile the Sass files if the frontend toolkit isn't checked out
however Jekyll doesn't exit with a helpful error, so the build doesn't fail.

This commit tests for the expected CSS files and will fail the compile if any
of them are not found.

/cc @annashipman @bradleywright 
