### PR TITLE
Update _footer.html

### DIFF
--- a/_includes/_footer.html
+++ b/_includes/_footer.html
@@ -1,13 +1,14 @@
 <footer class="group js-footer" id="footer" role="contentinfo">
   <div class="footer-wrapper">
     <nav class="footer-categories"><div class="footer-explore">
-      <h2>Explore GOV.UK</h2>
+      <h2>Services and Information</h2>
 
       <ul>
-        <li><a href="/browse/driving">Driving, transport and travel</a></li>
+        <li><a href="/browse/driving">Driving and transport</a></li>
         <li><a href="/browse/benefits">Benefits</a></li>
         <li><a href="/browse/business">Businesses and self-employed</a></li>
         <li><a href="/browse/employing-people">Employing people</a></li>
+        <li><a href="/browse/abroad">Passports, travel and living abroad</a></li>        
         <li><a href="/browse/education">Education and learning</a></li>
         <li><a href="/browse/working">Working, jobs and pensions</a></li>
         <li><a href="/browse/housing">Housing and local services</a></li>
@@ -20,11 +21,12 @@
     </div>
 
     <div class="footer-inside-government">
-      <h2><a href="/government">Inside Government</a></h2>
+      <h2><a href="/government">Departments and Policy</a></h2>
 
       <ul>
         <li><a href="/government/how-government-works">How government works</a></li>
         <li><a href="/government/organisations">Departments</a></li>
+        <li><a href="/government/world">Worldwide</a></li>
         <li><a href="/government/topics">Topics</a></li>
         <li><a href="/government/policies">Policies</a></li>
         <li><a href="/government/publications">Publications</a></li>


### PR DESCRIPTION
Updated the footer to match the main GOV.UK one - headings are correct, and new items in each list are added (Worldwide and Living Abroad). Styling still needs to be fixed, though.

I presumed that there was a single footer code snippet in use across all parts of the site, but I guess not in this case.
