### PR TITLE
Changing it's to its in the intro to Option2: Wizard

### DIFF
--- a/service-manual/user-centered-design/designing-transactions.md
+++ b/service-manual/user-centered-design/designing-transactions.md
@@ -95,7 +95,7 @@ All sections are positioned on a single page.
 
 ### Option2 : Wizard
 
-Each section goes on it's own page.
+Each section goes on its own page.
 
 ![Diagram showing each section on it's own page](/service-manual/assets/images/designing-transactions/wizard.png)
 


### PR DESCRIPTION
Typo under Option2: Wizard
It's should be its.

Jarring in a useful page.

Tom Ruppel
(Currently working at DECC)
