### PR TITLE
Remove references to "empowering" CTOs.

### DIFF
--- a/service-manual/technology/architecture.md
+++ b/service-manual/technology/architecture.md
@@ -1,7 +1,6 @@
 ---
 layout: detailed-guidance
 title: Technology architecture
-subtitle: Empowering Chief Technology Officers across government
 category: technology
 type: guide
 audience:

--- a/service-manual/technology/index.md
+++ b/service-manual/technology/index.md
@@ -1,7 +1,6 @@
 ---
 layout: category-index
 title: Guidance for CTOs
-subtitle: Empowering Chief Technology Officers across government
 category: technology
 type: category-index
 audience:


### PR DESCRIPTION
This is one of the words to avoid on GOV.UK, as [the style guide says](https://www.gov.uk/designprinciples/styleguide#plain-english--mandatory-for-all-of-govuk).
