### PR TITLE
Remove word

### DIFF
--- a/service-manual/user-centered-design/know-your-users.md
+++ b/service-manual/user-centered-design/know-your-users.md
@@ -60,6 +60,6 @@ The following techniques may be useful when conducting user research
 
 ## User research briefs
 
-As you and conduct or procure specific rounds of user research you will want to ensure these are conducted in a consistent way, delivering results in a useful format.
+As you conduct or procure specific rounds of user research you will want to ensure these are conducted in a consistent way, delivering results in a useful format.
 
 [Learn how to write user research briefs](/service-manual/user-centered-design/user-research/user-research-briefs.html)


### PR DESCRIPTION
In the "User research briefs" section it reads: - 

"As you and conduct or procure specific rounds of user research you will want to ensure these are conducted in a consistent way, delivering results in a useful format." 

This doesn't read right, so I recommend removing the word "and" near the start of the first sentence.
