### PR TITLE
change link for requesting header and footer templates

### DIFF
--- a/service-manual/user-centered-design/resources/header-footer.md
+++ b/service-manual/user-centered-design/resources/header-footer.md
@@ -82,5 +82,5 @@ The footer should also state the appropriate copyright and licence notices.
 
 ## Templates and styles
 
-If need access to the templates and styles please make a request via [the GOV.UK support form](/support/internal).
+If you need access to the templates and styles, please make a request via [the GOV.UK support form](/support/internal).
 


### PR DESCRIPTION
The form found at `/feedback` is actually the public contact form;
for more direct and expedient routing, template requests should be coming
in through the government form
