### PR TITLE
Replaced URI with URL in API design principles

### DIFF
--- a/service-manual/making-software/apis.md
+++ b/service-manual/making-software/apis.md
@@ -51,7 +51,7 @@ a worldwide audience is difficult. While proprietary and open technologies
 abound for machine-to-machine communication, none of them have the web's
 interoperability, reach and ability to scale.
 
-Standards are powerful agreements, and nowhere are agreements more quickly established and adopted than on the web. Using HTTP (Hypertext Transfer Protocol) and URLs (uniform resource identifiers), the core technologies of the web, along with emergent standards such as [JSON](http://www.json.org/) and [OAuth](http://en.wikipedia.org/wiki/OAuth) changes a website from [a retail shop window into a wholesaler](http://www.cabinetoffice.gov.uk/resource-library/directgov-2010-and-beyond-revolution-not-evolution), meeting our design principle to [build digital services, not websites](https://www.gov.uk/designprinciples#eighth).
+Standards are powerful agreements, and nowhere are agreements more quickly established and adopted than on the web. Using HTTP (Hypertext Transfer Protocol) and URLs (uniform resource locator), the core technologies of the web, along with emergent standards such as [JSON](http://www.json.org/) and [OAuth](http://en.wikipedia.org/wiki/OAuth) changes a website from [a retail shop window into a wholesaler](http://www.cabinetoffice.gov.uk/resource-library/directgov-2010-and-beyond-revolution-not-evolution), meeting our design principle to [build digital services, not websites](https://www.gov.uk/designprinciples#eighth).
 
 ### Give each thing a bookmarkable URL
 Expose data as a set of resources, offering a [clean URL](http://en.wikipedia.org/wiki/Clean_URL) for each thing, and each collection of things.


### PR DESCRIPTION
This change in wording from URI to URL might seem like a mildly contentious thing, but follows the government open standards profile for using resolvable URLs for [persistent, resolvable identifiers](http://standards.data.gov.uk/profile/persistent-resolvable-identifiers-profile).
