### PR TITLE
Disable the creation of gzipped assets

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -46,3 +46,4 @@ kramdown:
 assets:
   dirname: service-manual/assets
   baseurl: /service-manual/assets/
+  gzip: false


### PR DESCRIPTION
From [a comment by @jabley](https://github.com/alphagov/government-service-design-manual/pull/255#issuecomment-28063890).

Perhaps we should just let nginx handle gzipping?

If this is merged we should do the same thing on alphagov/transformation-dashboard#13.
