### PR TITLE
Improve DNS guidance

### DIFF
--- a/service-manual/domain-names/how-they-work.md
+++ b/service-manual/domain-names/how-they-work.md
@@ -32,7 +32,7 @@ manage the detailed configuration of which servers the domain name points to, an
 ## How is this different to how direct.gov.uk domains have been managed?
 
 The domain direct.gov.uk was managed by the DirectGov Service Desk directly (and inherited by GDS).
-All domains were administered by DirectGov and each subdomain did not have it's own DNS servers.
+All domains were administered by DirectGov and each subdomain did not have its own DNS servers.
 
 This meant that services would need to give details of the names and IP addresses of their webservers
 to DirectGov, who would directly create the necessary A and CNAME records. The DirectGov Service Desk
@@ -55,4 +55,4 @@ configuration. You might introduce load balancers or content delivery networks, 
 providers, or your provider might need to change the IP addresses that your servers are assigned. In any
 of those cases it is important that your team is able to quickly respond to the situation and make any
 relevant changes with as few intermediaries as possible. By delegating control GDS ensures that control
-is in the hands of the service team nd not blocked by a central authority.
+is in the hands of the service team and not blocked by a central authority.

--- a/service-manual/domain-names/setting-up.md
+++ b/service-manual/domain-names/setting-up.md
@@ -26,9 +26,8 @@ breadcrumbs:
 To make sure that the right user journey (appropriate start/end pages, clear domain names) are
 set up for a new service it's important that you engage with the GOV.UK team within GDS early.
 
-If you're not already in conversation with the team about your service, you can start the
-process by e-mailing gdsapprovals@digital.cabinet-office.gov.uk who will discuss with you
-the best name for your Service Domain and the start pages on GOV.UK.
+You can start the service domain name process by emailing [gdsapprovals@digital.cabinet-office.gov.uk](gdsapprovals@digital.cabinet-office.gov.uk)
+who will discuss with you the best name for your Service Domain and the start pages on GOV.UK.
 
 While you are waiting for this process, you should start looking at where you will host the
 DNS, as GDS will delegate control of your Service Domain to you. You should


### PR DESCRIPTION
Many services are being sent to the Infrastructure Team without
either the correct information about DNS servers, or are expecting
GDS to host the DNS for their service.

This PR makes it much more explicit about how service.gov.uk DNS
management differs from direct.gov.uk management and what information
needs to be provided.
