### PR TITLE
Remove @dir from absolute_url generation

### DIFF
--- a/_plugins/jekyll_rummageable/page.rb
+++ b/_plugins/jekyll_rummageable/page.rb
@@ -9,7 +9,7 @@ module Jekyll
     end
 
     def absolute_url
-      "#{@dir}#{url}"
+      url
     end
 
     def output_is_html?


### PR DESCRIPTION
Bumping the Jekyll version means that `url` now includes `@dir` as well as the filename.

Fixes the search-index.json
