### PR TITLE
Fix hover colour of links in survey bar

### DIFF
--- a/_assets/stylesheets/helpers/_user-satisfaction-survey.scss
+++ b/_assets/stylesheets/helpers/_user-satisfaction-survey.scss
@@ -1,6 +1,9 @@
 #user-satisfaction-survey {
-  a:visited {
-    color: $white;
+  div.wrapper p {
+    a:visited,
+    a:hover {
+      color: $white;
+    }
   }
 }
 


### PR DESCRIPTION
This is to match the survey bar across gov.uk.

Ideally header-and-footer-only.css would be updated from static to
get new survey bar styles, but the service manual is so far behind
that the latest version of static doesn't seem to work any longer.
