### PR TITLE
Update browser support guidelines

### DIFF
--- a/service-manual/user-centered-design/browsers-and-devices.md
+++ b/service-manual/user-centered-design/browsers-and-devices.md
@@ -62,7 +62,7 @@ Note: An exception is made for IE6, as this is still in large-scale use in gover
 | iOS | 5 | Mobile Safari | Functional |
 | Android | 4.x | Google Chrome | Compliant |
 | Android | 2.3 | Android Browser | Functional |
-| Blackberry | 6+ | &nbsp; | Functional |
+| BlackBerry | 6+ | &nbsp; | Functional |
 
 ##Developing universally accessible services
 


### PR DESCRIPTION
- IE11 has been released, so in my opinion there's not point creating new services that don't support it
- Safari 5 is old (Should we make Safari 6 'Functional'?)
- iOS 7 is new (Should we remove iOS 5 support from here? Seems like it might still be quite widely used.)
- BlackBerry has two capital Bs in it
