### PR TITLE
Caveat about using the same DNS provider as GDS

### DIFF
--- a/service-manual/domain-names/setting-up.md
+++ b/service-manual/domain-names/setting-up.md
@@ -40,3 +40,7 @@ GDS contact who will put you in touch with the GDS Infrastructure Team to arrang
 1. Service name e.g. {service-name}.service.gov.uk
 2. DNS servers to delegate to (ask your technical team to see [the guidance on DNS delegation](/service-manual/domain-names/how-they-work))
 3. Date you need it by (at least 5 working days notice)
+
+If you are intending to use the "Managed DNS" product offered by Dyn, then you will need to give as much notice as possible, as Dyn is currently
+used to manage the main service.gov.uk DNS domain. Dyn requires a signed letter of authorisation from GDS and work on their systems in order to
+manage sub-zones of service.gov.uk via other customer accounts -- this may take additional time to arrange.


### PR DESCRIPTION
I wasn't sure whether this is appropriate for the service manual, as it
references a particular provider (I have avoided hyperlinking to avoid the
idea that we are promoting them over any other).

We have an issue when Transactional Services want to use the same DNS provider
as GDS uses to manage the service.gov.uk domain. In order for the backend
systems to know which customer account is authorative for that particular
record, the provider needs to make some alterations and requires a signed
letter of authorisation from both parties.

As this is outside of our control and may affect timescales, I thought it
worth documenting here.

/cc @daibach
