### PR TITLE
Update "Browsers and devices"

### DIFF
--- a/service-manual/user-centred-design/browsers-and-devices.md
+++ b/service-manual/user-centred-design/browsers-and-devices.md
@@ -42,11 +42,13 @@ Two distinct levels of support are given and denoted next to each browser. Where
 ### Desktop
 
 <table>
+  <thead>
+    <tr>
+      <th scope="col">Operating system</th><th scope="col">Browser</th><th scope="col">Support</th>
+    </tr>
+  </thead>
   <tr>
-    <th>Operating system</th><th>Browser</th><th>Support</th>
-  </tr>
-  <tr>
-    <td rowspan="4">Windows</td><td>Internet Explorer 7+</td><td>Compliant</td>
+    <th scope="row" rowspan="4">Windows</th><td>Internet Explorer 7+</td><td>Compliant</td>
   </tr>
   <tr>
     <td>Internet Explorer 6</td><td>Functional</td>
@@ -58,7 +60,7 @@ Two distinct levels of support are given and denoted next to each browser. Where
     <td>Mozilla Firefox (latest version)</td><td>Compliant</td>
   </tr>
   <tr>
-    <td rowspan="3">Mac OS X</td><td>Safari 7</td><td>Compliant</td>
+    <th scope="row" rowspan="3">Mac OS X</th><td>Safari 7</td><td>Compliant</td>
   </tr>
   <tr>
     <td>Google Chrome (latest version)</td><td>Compliant</td>
@@ -71,11 +73,13 @@ Two distinct levels of support are given and denoted next to each browser. Where
 ### Small screen devices
 
 <table>
+  <thead>
+    <tr>
+      <th scope="col">Operating system</th><th scope="col">Version</th><th scope="col">Browser</th><th scope="col">Support</th>
+    </tr>
+  </thead>
   <tr>
-    <th>Operating system</th><th>Version</th><th>Browser</th><th>Support</th>
-  </tr>
-  <tr>
-    <td rowspan="4">iOS</td><td rowspan="2">7</td><td>Mobile Safari</td><td>Compliant</td>
+    <th scope="row" rowspan="4">iOS</th><td rowspan="2">7</td><td>Mobile Safari</td><td>Compliant</td>
   </tr>
   <tr>
     <td>Google Chrome</td><td>Compliant</td>
@@ -87,7 +91,7 @@ Two distinct levels of support are given and denoted next to each browser. Where
     <td>5</td><td>Mobile Safari</td><td>Functional</td>
   </tr>
   <tr>
-    <td rowspan="3">Android</td><td rowspan="2">4.x</td><td>Google Chrome</td><td>Compliant</td>
+    <th scope="row" rowspan="3">Android</th><td rowspan="2">4.x</td><td>Google Chrome</td><td>Compliant</td>
   </tr>
   <tr>
     <td>Android Browser</td><td>Compliant</td>
@@ -96,10 +100,10 @@ Two distinct levels of support are given and denoted next to each browser. Where
     <td>2.3</td><td>Android Browser</td><td>Functional</td>
   </tr>
   <tr>
-    <td>Windows Phone</td><td>8</td><td>Internet Explorer 10</td><td>Functional</td>
+    <th scope="row">Windows Phone</th><td>8</td><td>Internet Explorer 10</td><td>Functional</td>
   </tr>
   <tr>
-    <td>BlackBerry</td><td>7.1</td><td>BlackBerry Browser</td><td>Functional</td>
+    <th scope="col">BlackBerry</th><td>7.1</td><td>BlackBerry Browser</td><td>Functional</td>
   </tr>
 </table>
 


### PR DESCRIPTION
I've made some changes to the browsers and devices page and would appreciate feedback from anyone who self-identifies as a browser nerd.

I'm working on the assumption that we want to keep something BlackBerry related in that table and so I've added things that are more popular than it.

If things are going to be removed, this is the order they should be removed in:
1. BlackBerry 7.1: 0.2%
2. Windows Phone 8 IE 10: 0.4%
3. iOS 7 Google Chrome: 0.8% ("supported" for 95% of users)
4. Android Browser 4.x: 3.7% ("supported" for 95% of users)

BlackBerry 6 isn't worth keeping on the list anymore. It's got 0.06% of visits, which is less than Opera Mini, Opera on the desktop, Amazon Silk and Mobile Safari on iOS 4.3.

I think we're also getting closer to being able to drop IE 6 from this page. It's now at 0.35% and declining almost every month, and is technically unsupported to get us to 95% of users. I haven't done that yet though.
