### PR TITLE
Quick prototype of creating a book format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 _site/
 .search-index.json
 tmp/*
+node_modules/

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,0 +1,181 @@
+# Summary
+
+This is a snapshot of the Government Service Design Manual. It contains current thoughts about how best to create great digital services designed around the needs of users.
+
+* [Agile](service-manual/agile/index.md)
+    * [Features of agile](service-manual/agile/features-of-agile.md)
+    * [What agile looks like](service-manual/agile/what-agile-looks-like.md)
+    * [Continuous Delivery](service-manual/agile/continuous-delivery.md)
+    * [Quality](service-manual/agile/quality.md)
+    * [Running retrospectives](service-manual/agile/running-retrospectives.md)
+    * [Writing user stories](service-manual/agile/writing-user-stories.md)
+* [Assisted Digital](service-manual/assisted-digital/index.md)
+    * [Action plan](service-manual/assisted-digital/action-plan.md)
+    * [User research](service-manual/assisted-digital/assisted-digital-user-research.md)
+* [Communications](service-manual/communications/index.md)
+    * [Blogs](service-manual/communications/blogs.md)
+    * [Increasing digital takeup](service-manual/communications/increasing-digital-takeup.md)
+* [Content Designers](service-manual/content-designers/index.md)
+    * [Transactions style guide](service-manual/content-designers/transactions-style-guide.md)
+    * [Example template for privacy note](service-manual/content-designers/privacy-note-template-for-services.md)
+* [Designers](service-manual/designers/index.md)
+* [Developers](service-manual/developers/index.md)
+* [Digital by default service standard](service-manual/digital-by-default/index.md)
+  * [Scope](service-manual/digital-by-default/scope-of-the-standard.md)
+  * [Assessments](service-manual/digital-by-default/assessments-at-gds.md)
+  * [Awarding the standard](service-manual/digital-by-default/awarding-the-standard.md)
+  * [Failure to meet the standard](service-manual/digital-by-default/failure-to-meet-the-standard.md)
+  * [Maintaining the standard](service-manual/digital-by-default/maintaining-the-standard.md)
+  * [Self certification](service-manual/digital-by-default/self-certification.md)
+* [Identity assurance](service-manual/identity-assurance/index.md)
+
+<!-- service-manual/domain-names/asset-hosts.md
+service-manual/domain-names/email.md
+service-manual/domain-names/how-they-work.md
+service-manual/domain-names/https.md
+service-manual/domain-names/index.md
+service-manual/domain-names/service-subdomain-names.md
+service-manual/domain-names/setting-up.md
+
+
+service-manual/chief-technology-officers/index.md
+
+
+service-manual/feedback/index.md
+service-manual/making-software/accessibility-testing.md
+service-manual/making-software/analytics-tools.md
+service-manual/making-software/apis.md
+service-manual/making-software/choosing-technology.md
+service-manual/making-software/code-testing.md
+service-manual/making-software/configuration-management.md
+service-manual/making-software/cookies.md
+service-manual/making-software/deployment.md
+service-manual/making-software/development-environment.md
+service-manual/making-software/index.md
+service-manual/making-software/information-security.md
+service-manual/making-software/logins.md
+service-manual/making-software/open-standards-and-licensing.md
+service-manual/making-software/progressive-enhancement.md
+service-manual/making-software/release-strategies.md
+service-manual/making-software/sandbox-and-staging-servers.md
+service-manual/making-software/standalone-apps.md
+service-manual/making-software/testing-in-agile.md
+service-manual/making-software/version-control.md
+
+service-manual/measurement/completion-rate.md
+service-manual/measurement/cost-per-transaction.md
+service-manual/measurement/digital-takeup.md
+service-manual/measurement/index.md
+service-manual/measurement/other-kpis.md
+service-manual/measurement/performance-platform.md
+service-manual/measurement/user-satisfaction.md
+service-manual/measurement/using-data.md
+
+service-manual/operations/devops.md
+service-manual/operations/helpdesk.md
+service-manual/operations/hosting.md
+service-manual/operations/index.md
+service-manual/operations/load-and-performance-testing.md
+service-manual/operations/managing-user-support.md
+service-manual/operations/monitoring.md
+service-manual/operations/operating-servicegovuk-subdomains.md
+service-manual/operations/penetration-testing.md
+service-manual/operations/uptime-and-availability.md
+
+service-manual/performance-analysts/index.md
+
+service-manual/phases/alpha.md
+service-manual/phases/beta.md
+service-manual/phases/discovery.md
+service-manual/phases/ideal-alphas.md
+service-manual/phases/index.md
+service-manual/phases/live.md
+service-manual/phases/retirement.md
+
+service-manual/service-managers/index.md
+
+service-manual/start/index.md
+
+service-manual/technology/architecture.md
+service-manual/technology/code-of-practice.md
+service-manual/technology/culture-that-supports-change.md
+service-manual/technology/end-user-devices.md
+service-manual/technology/government-as-a-platform.md
+service-manual/technology/index.md
+service-manual/technology/open-data.md
+service-manual/technology/security-as-enabler.md
+service-manual/technology/service-integration.md
+service-manual/technology/spending-controls.md
+
+service-manual/the-team/accessibility.md
+service-manual/the-team/content-designer.md
+service-manual/the-team/delivery-manager.md
+service-manual/the-team/designer.md
+service-manual/the-team/developer.md
+service-manual/the-team/digital-leader.md
+service-manual/the-team/index.md
+service-manual/the-team/induction-and-development.md
+service-manual/the-team/recruitment/hub.md
+service-manual/the-team/recruitment/index.md
+service-manual/the-team/recruitment/job-descriptions.md
+service-manual/the-team/recruitment/performance-analyst-jd.md
+service-manual/the-team/recruitment/salary-advice.md
+service-manual/the-team/recruitment/scs-orgdesign.md
+service-manual/the-team/service-manager.md
+service-manual/the-team/user-researcher.md
+service-manual/the-team/web-operations.md
+service-manual/the-team/working-environment.md
+service-manual/the-team/working-with-specialists.md
+
+service-manual/themes/index.md
+
+service-manual/user-centred-design/accessibility.md
+service-manual/user-centred-design/browsers-and-devices.md
+service-manual/user-centred-design/card-sorting.md
+service-manual/user-centred-design/choosing-appropriate-formats.md
+service-manual/user-centred-design/data-visualisation.md
+service-manual/user-centred-design/designing-transactions.md
+service-manual/user-centred-design/how-users-read.md
+service-manual/user-centred-design/index.md
+service-manual/user-centred-design/introduction-to-user-research.md
+service-manual/user-centred-design/know-your-users.md
+service-manual/user-centred-design/print-forms.md
+service-manual/user-centred-design/resources/buttons.md
+service-manual/user-centred-design/resources/captcha.md
+service-manual/user-centred-design/resources/colour-palettes.md
+service-manual/user-centred-design/resources/creating-accessible-PDFs.md
+service-manual/user-centred-design/resources/forms.md
+service-manual/user-centred-design/resources/grids.md
+service-manual/user-centred-design/resources/header-footer.md
+service-manual/user-centred-design/resources/registration-form.md
+service-manual/user-centred-design/resources/sass-repositories.md
+service-manual/user-centred-design/resources/shared-asset-libraries.md
+service-manual/user-centred-design/resources/typography.md
+service-manual/user-centred-design/resources/writing-for-transactions.md
+service-manual/user-centred-design/service-look-and-feel.md
+service-manual/user-centred-design/user-centred-design-alpha-beta.md
+service-manual/user-centred-design/user-needs.md
+service-manual/user-centred-design/user-research/community-user-groups.md
+service-manual/user-centred-design/user-research/discussion-guides.md
+service-manual/user-centred-design/user-research/ethnographic-research.md
+service-manual/user-centred-design/user-research/expert-review.md
+service-manual/user-centred-design/user-research/focus-groups-mini-groups-interviews.md
+service-manual/user-centred-design/user-research/guerrilla-testing.md
+service-manual/user-centred-design/user-research/index.md
+service-manual/user-centred-design/user-research/lab-based-user-testing.md
+service-manual/user-centred-design/user-research/multivariate-testing.md
+service-manual/user-centred-design/user-research/online-omnibus-survey.md
+service-manual/user-centred-design/user-research/online-research-panels.md
+service-manual/user-centred-design/user-research/remote-usability.md
+service-manual/user-centred-design/user-research/same-day-user-testing.md
+service-manual/user-centred-design/user-research/sampling-methodologies.md
+service-manual/user-centred-design/user-research/sentiment-analysis.md
+service-manual/user-centred-design/user-research/survey-design.md
+service-manual/user-centred-design/user-research/user-research-briefs.md
+service-manual/user-centred-design/user-research/user-research-surveys.md
+service-manual/user-centred-design/user-research/user-research-tools.md
+service-manual/user-centred-design/working-with-prototypes.md
+service-manual/user-researchers/index.md
+
+service-manual/web-ops/index.md
+ -->

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "government-service-design-manual",
+  "repository": "https://github.com/alphagov/government-service-design-manual",
+  "version": "0.1.0",
+  "devDependencies": {
+    "grunt": "~0.4.2",
+    "grunt-cli": "0.1.11",
+    "gitbook": "~0.6.3",
+    "gitbook-pdf": "~0.0.2"
+  }
+}


### PR DESCRIPTION
*Please do not merge*

We have been asked for a pdf version of the service manual in the past. I’m
not completely sure what the user need is for this, but here is a very basic
sketch around that.

To try it out, you’ll need to install a few things:

* `sudo aptitude install node`
* `npm install`

If that works, you can then create different versions of the content:

```
$ gitbook pdf ./
```