### PR TITLE
Cleaning up the Resources for developers section

### DIFF
--- a/service-manual/agile/features-of-agile.md
+++ b/service-manual/agile/features-of-agile.md
@@ -5,8 +5,8 @@ subtitle: Sprints, stand-ups and other regular meetings
 category: agile
 type: guide
 audience:
-  primary:
-  secondary: service-managers, designers, delivery-managers, web-ops, developers, tech-archs, performance-analysts, user-researchers, qa, content-designers
+  primary: developers
+  secondary: service-managers, designers, delivery-managers, web-ops, tech-archs, performance-analysts, user-researchers, qa, content-designers
 status: draft
 phases:
   - alpha

--- a/service-manual/assisted-digital/action-plan.md
+++ b/service-manual/assisted-digital/action-plan.md
@@ -5,7 +5,7 @@ subtitle: How to develop assisted digital support
 category: assisted-digital
 type: guide
 audience:
-  primary: service-managers, designers, developers, tech-archs, performance-analysts, user-researchers
+  primary: service-managers, designers, tech-archs, performance-analysts, user-researchers
 status: draft
 phases:
   - discovery
@@ -30,8 +30,7 @@ The information in this document will help you to:
 * develop assisted digital support that meets user needs and provides good value for money
 
 <figure class="media-player-wrapper video">
-  <a href="https://www.youtube.com/watch?feature=player_embedded&v=hJUL-nz1crk">Watch the team describe how assisted digital is part of a service</a
-  >
+  <a href="https://www.youtube.com/watch?feature=player_embedded&v=hJUL-nz1crk">Watch the team describe how assisted digital is part of a service</a>
 </figure>
 
 ## Discovery: understanding your assisted digital users and their needs

--- a/service-manual/content-designers/privacy-note-template-for-services.md
+++ b/service-manual/content-designers/privacy-note-template-for-services.md
@@ -5,7 +5,7 @@ subtitle: Writing questions, wording for labels, addressing the user and more
 category: user-centred-design
 type: guide
 audience:
-  primary: service-managers, designers, developers, content-designers
+  primary: service-managers, designers, content-designers
   secondary: performance-analysts, user-researchers
 status: draft
 phases:

--- a/service-manual/identity-assurance/index.md
+++ b/service-manual/identity-assurance/index.md
@@ -5,7 +5,7 @@ subtitle: For government service providers
 category: identity-assurance
 type: guide
 audience:
-  primary: service-managers, designers, delivery-managers, developers, tech-archs, performance-analysts, user-researchers, qa, content-designers
+  primary: service-managers, designers, delivery-managers,  tech-archs, performance-analysts, user-researchers, qa, content-designers
   secondary:
 status: draft
 phases:

--- a/service-manual/making-software/apis.md
+++ b/service-manual/making-software/apis.md
@@ -5,8 +5,8 @@ subtitle: Using and creating Application Programming Interfaces
 category: making-software
 type: guide
 audience:
-  primary: service-managers, tech-archs
-  secondary: developers, chief-technology-officers
+  primary: service-managers, tech-archs, developers
+  secondary: chief-technology-officers
 status: draft
 phases:
   - beta

--- a/service-manual/making-software/choosing-technology.md
+++ b/service-manual/making-software/choosing-technology.md
@@ -5,8 +5,8 @@ subtitle: How to go about choosing what software tools to use
 category: making-software
 type: guide
 audience:
-  primary: service-managers, tech-archs
-  secondary: developers, web-ops, chief-technology-officers
+  primary: service-managers, tech-archs, developers
+  secondary: web-ops, chief-technology-officers
 status: draft
 phases:
   - alpha

--- a/service-manual/making-software/information-security.md
+++ b/service-manual/making-software/information-security.md
@@ -5,8 +5,8 @@ subtitle: Ensuring user data stays secure
 category: making-software
 type: guide
 audience:
-  primary: service-managers, web-ops, developers, tech-archs,
-  secondary: delivery-managers, qa
+  primary: service-managers, web-ops, tech-archs,
+  secondary: developers, delivery-managers, qa
 status: draft
 phases:
   - alpha

--- a/service-manual/making-software/testing-in-agile.md
+++ b/service-manual/making-software/testing-in-agile.md
@@ -5,8 +5,8 @@ subtitle: How to get testing right
 category: agile
 type: guide
 audience:
-  primary: qa
-  secondary: service-managers, web-ops, developers, tech-archs
+  primary: qa, developers
+  secondary: service-managers, web-ops, tech-archs
 theme: agile
 status: draft
 phases:

--- a/service-manual/making-software/version-control.md
+++ b/service-manual/making-software/version-control.md
@@ -5,8 +5,8 @@ subtitle: Ensure the team can collaborate on code
 category: making-software
 type: guide
 audience:
-  primary: 
-  secondary: service-managers, developers, tech-archs, web-ops
+  primary: developers
+  secondary: service-managers, tech-archs, web-ops
 status: draft
 phases:
   - alpha

--- a/service-manual/measurement/user-satisfaction.md
+++ b/service-manual/measurement/user-satisfaction.md
@@ -6,7 +6,7 @@ category: measurement
 type: guide
 audience:
   primary: service-managers, performance-analysts
-  secondary: designers, developers, content-designers
+  secondary: designers, content-designers
 phases:
   - beta
   - live

--- a/service-manual/measurement/using-data.md
+++ b/service-manual/measurement/using-data.md
@@ -7,7 +7,7 @@ category: measurement
 type: guide
 audience:
   primary: service-managers, performance-analysts
-  secondary: designers, developers, qa, content-designers
+  secondary: designers, qa, content-designers
 phases:
   - beta
   - live

--- a/service-manual/operations/devops.md
+++ b/service-manual/operations/devops.md
@@ -6,8 +6,8 @@ category: operations
 type: guide
 status: draft
 audience:
-  primary: web-ops
-  secondary: service-managers, developers, tech-archs
+  primary: web-ops, developers
+  secondary: service-managers, tech-archs
 breadcrumbs:
   -
     title: Home

--- a/service-manual/operations/managing-user-support.md
+++ b/service-manual/operations/managing-user-support.md
@@ -6,7 +6,7 @@ category: operations
 type: guide
 audience: 
   primary: 
-  secondary: service-managers, designers, developers
+  secondary: service-managers, designers
 status: draft
 phases:
  - alpha

--- a/service-manual/operations/operating-servicegovuk-subdomains.md
+++ b/service-manual/operations/operating-servicegovuk-subdomains.md
@@ -6,7 +6,7 @@ category: operations
 type: guide
 audience:
   primary: tech-archs
-  secondary: service-managers, web-ops, developers
+  secondary: service-managers, web-ops
 status: draft
 breadcrumbs:
   -

--- a/service-manual/technology/spending-controls.md
+++ b/service-manual/technology/spending-controls.md
@@ -6,7 +6,7 @@ category: technology
 type: guide
 audience:
   primary: chief-technology-officers
-  secondary: service-managers, designers, delivery-managers, developers, tech-archs
+  secondary: service-managers, designers, delivery-managers, tech-archs
 status: draft
 phases:
   - discovery

--- a/service-manual/the-team/accessibility.md
+++ b/service-manual/the-team/accessibility.md
@@ -5,7 +5,7 @@ subtitle: What your team needs to build for inclusion
 category: the-team
 type: guide
 audience:
-  primary: designers, developers
+  primary: designers
   secondary: service-managers
 status: draft
 phases:

--- a/service-manual/the-team/working-environment.md
+++ b/service-manual/the-team/working-environment.md
@@ -6,7 +6,7 @@ category: the-team
 type: guide
 audience:
   primary: delivery-managers
-  secondary: service-managers, designers, developers, tech-archs, user-researchers, performance-analysts
+  secondary: service-managers, designers, tech-archs, user-researchers, performance-analysts
 status: draft
 phases:
   - discovery

--- a/service-manual/user-centred-design/choosing-appropriate-formats.md
+++ b/service-manual/user-centred-design/choosing-appropriate-formats.md
@@ -5,8 +5,8 @@ subtitle: Help your users by providing content in a format they can use
 category: user-centred-design
 type: guide
 audience:
-  primary: designers, developers, tech-archs, user-researchers, service-managers
-  secondary: delivery-managers, performance-analysts
+  primary: designers, tech-archs, user-researchers, service-managers
+  secondary: delivery-managers, performance-analysts, developers
 status: draft
 phases:
   - beta

--- a/service-manual/user-centred-design/how-users-read.md
+++ b/service-manual/user-centred-design/how-users-read.md
@@ -5,7 +5,7 @@ subtitle: Reading age, reading online, plain English, learning disabilities
 category: user-centred-design
 type: guide
 audience:
-  primary: designers, developers, user-researchers, qa, content-designers
+  primary: designers, user-researchers, qa, content-designers
   secondary: service-managers
 status: draft
 phases:

--- a/service-manual/user-centred-design/resources/captcha.md
+++ b/service-manual/user-centred-design/resources/captcha.md
@@ -5,8 +5,8 @@ subtitle: Build to the GOV.UK style
 category: design-and-development-resources
 type: resource
 audience:
-    primary: designers, developers
-    secondary:
+    primary: designers
+    secondary: developers
 status: draft
 phases:
   - alpha

--- a/service-manual/user-centred-design/resources/header-footer.md
+++ b/service-manual/user-centred-design/resources/header-footer.md
@@ -5,8 +5,8 @@ subtitle: Guidance on using the GOV.UK header
 category: user-centred-design
 type: guide
 audience:
-  primary: designers, developers
-  secondary:
+  primary: designers
+  secondary: developers
 status: draft
 phases:
   - alpha

--- a/service-manual/user-centred-design/resources/sass-repositories.md
+++ b/service-manual/user-centred-design/resources/sass-repositories.md
@@ -9,7 +9,8 @@ phases:
   - beta
   - live
 audience:
-  primary: designers, developers
+  primary: designers
+  secondary: developers
 status: draft
 breadcrumbs:
   -

--- a/service-manual/user-centred-design/user-centred-design-alpha-beta.md
+++ b/service-manual/user-centred-design/user-centred-design-alpha-beta.md
@@ -5,8 +5,8 @@ subtitle: Combining design and research to create user focused services
 category: user-centred-design
 type: guide
 audience:
-  primary: service-managers, designers, developers, performance-analysts, user-researchers, qa
-  secondary:
+  primary: service-managers, designers, performance-analysts, user-researchers, qa
+  secondary: developers
 status: draft
 phases:
   - alpha


### PR DESCRIPTION
Different people use the tags differently, with some pages having
_everyone_ as the primary audience and others being more selective.
This to me has led to a resources page that doesn't really work for
anyone.

I've tried to take a view on what a developer might be
interested in on the main resources page, moving more specialist content
to the secondary list.

This is probably quite opinionated so suggestions welcome. I'm not
saying something isn't important, I'm saying some things are relevant to
everyone (version control, progressive enhancement, testing) and some
things (CAPCHAs, load testing, Sass) are relevant either to specialists
or occasionally or both.

Note that this _only_ fixes the developer page. The problem is true of the other pages as well.
