### PR TITLE
Make elements page show up in search

### DIFF
--- a/_plugins/jekyll_rummageable/indexer.rb
+++ b/_plugins/jekyll_rummageable/indexer.rb
@@ -62,7 +62,7 @@ module Jekyll
     end
 
     def is_index_page?(page)
-      page.is_a?(Jekyll::Page) && page.index?
+      page.is_a?(Jekyll::Page) && page.data['layout'].start_with?('role-index')
     end
 
     # We need DirectoryWatcher (the gem jekyll uses to detect changes to files


### PR DESCRIPTION
Only exclude index.md files that have a role-index layout. That layout means
that the page is mainly intended to be a catalogue of links rather than actual
content. A page of links should not show up in our search results, since that
would introduce an extra click to the user journey.

After this change:
- https://www.gov.uk/service-manual/search?q=captcha
  should only have a single result.
  https://www.gov.uk/service-manual/developers should not be in the
  results for that search. This is unchanged behaviour.
- https://www.gov.uk/service-manual/search?q=colour should have
  https://www.gov.uk/service-manual/user-centred-design/resources/elements
  in the results for that search. This is the new, desired behaviour.
