### PR TITLE
Link for published as OSS is incorrect

### DIFF
--- a/service-manual/making-software/choosing-technology.md
+++ b/service-manual/making-software/choosing-technology.md
@@ -64,7 +64,7 @@ Aim to have a clear understanding of the cost or implications of moving away fro
 In general, you should avoid making long-term commitments to any particular technology, product or supplier until you fully understand the problem you're trying to solve. Even then, you should make sure you maximise your future development options and avoid technology lock-in if possible.
 
 ## When to make new software versus using existing software
-Where there is an existing software solution which solves your problem, you should certainly consider using it. You're more likely to use existing software than to make new software when you have a commodity need. You may even be facing a niche problem that's peculiar to government which has already been solved by another part of the government -- or indeed another government -- and [released as open source software](https://github.com/alphagov/). 
+Where there is an existing software solution which solves your problem, you should certainly consider using it. You're more likely to use existing software than to make new software when you have a commodity need. You may even be facing a niche problem that's peculiar to government which has already been solved by another part of the government -- or indeed another government -- and [released as open source software](https://github.com/gds-operations/). 
 
 Development tools, build tools, utility libraries, databases and monitoring tools are all examples of software where many projects will have the same need, and it makes little sense to reinvent the wheel.
 


### PR DESCRIPTION
The link here for 'published as open source software' is to the alphagov organisation on GitHub, but this [explicitly isn't OSS](https://gds.blog.gov.uk/2012/10/12/coding-in-the-open/). A better link might be to the gds-operations organisation which [is OSS](https://github.com/gds-operations/open-source-guidelines), or better still, [Gareth's PR on OSS on the service manual](https://github.com/alphagov/government-service-design-manual/pull/360), when published.
