### PR TITLE
Link for published as OSS is incorrect

### DIFF
--- a/service-manual/making-software/choosing-technology.md
+++ b/service-manual/making-software/choosing-technology.md
@@ -115,7 +115,7 @@ If you’re using software to satisfy a rare or niche need, you’re less likely
 However, there are many situations where it makes more sense to use existing software like:
 
 * when you have a commodity need, because someone has probably already developed a solution to the common problem
-* facing a niche problem that’s peculiar to government, which has already been solved by another part of, or another, government and [released as open source software](https://github.com/alphagov/)
+* facing a niche problem that’s peculiar to government, which has already been solved by another part of, or another, government and [released as open source software](https://github.com/gds-operations/)
 
 In most cases, many projects will have the same need so it makes little sense to reinvent the wheel for certain types of software, eg:
 


### PR DESCRIPTION
The link here for 'published as open source software' is to the alphagov organisation on GitHub, but this [explicitly isn't OSS](https://gds.blog.gov.uk/2012/10/12/coding-in-the-open/). I have replaced this with a link to the gds-operations organisation which [is OSS](https://github.com/gds-operations/open-source-guidelines), though there might be a better link, such as [Gareth's PR on OSS on the service manual](https://github.com/alphagov/government-service-design-manual/pull/360), when published.
