### PR TITLE
Changing team name

### DIFF
--- a/service-manual/the-team/induction-and-development.md
+++ b/service-manual/the-team/induction-and-development.md
@@ -238,5 +238,5 @@ GDS technical architects will give a series of short talks and Q&A sessions abou
 
 To request a place on the induction programme or the open programme, please fill in this [SurveyMonkey form](https://www.surveymonkey.com/s/3PWSZNX)
 
-Any questions? Please contact the GDS Capabilities Team: [service-manager-programme@digital.cabinet-office.gov.uk](mailto:service-manager-programme@digital.cabinet-office.gov.uk)
+Any questions? Please contact the GDS Skills Team: [service-manager-programme@digital.cabinet-office.gov.uk](mailto:service-manager-programme@digital.cabinet-office.gov.uk)
 


### PR DESCRIPTION
The Capabilities team has been renamed to People and Skills, of which Skills looks after the Service Manager Induction programme.  This is the only instance in the Service Manual
