### PR TITLE
Split out linting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ aspell:
 	find service-manual -type f -name '*.md' -exec aspell -d, --master=british --mode=sgml -c '{}' \;
 
 test:
-	go test lint_test.go
+	go test tools/lint/mdlint/mdlint_test.go
 
 help:
 	@echo "Please use 'make <target>' where <target> is one of"

--- a/compile.sh
+++ b/compile.sh
@@ -10,7 +10,7 @@ fi
 bundle
 
 echo "Linting"
-go run lint.go service-manual
+go run tools/lint/lint.go service-manual
 
 echo "Updating submodules to ensure toolkit up to date..."
 git submodule update --init

--- a/tools/lint/lint.go
+++ b/tools/lint/lint.go
@@ -1,0 +1,83 @@
+// *Very* basic markdown linting, since we seem to keep publishing broken things.
+package main
+
+import (
+	"./mdlint"
+	"bufio"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func goWalk(location string) chan string {
+	chann := make(chan string) // unbuffered channel of synchronous error messages
+
+	go func() {
+		// Once we've walked all the files, close this channel to avoid deadlocks
+		defer close(chann)
+
+		filepath.Walk(location, func(path string, f os.FileInfo, err error) error {
+
+			// Only parse things that look like markdown
+			if !strings.HasSuffix(path, ".md") {
+				return nil
+			}
+
+			file, err := os.Open(path)
+
+			if err != nil {
+				panic(err)
+			}
+
+			defer file.Close()
+
+			reader := bufio.NewReader(file)
+
+			mdlint.Lint(reader, path, chann)
+
+			return nil
+		})
+	}()
+
+	return chann
+}
+
+func usage() {
+	fmt.Fprintf(os.Stderr, "Usage: %s\n", os.Args[0])
+	helpstring := `
+go run lint.go path/to/markdown/dir
+
+path/to/markdown/dir - mandatory directory which will be recursively linted
+`
+	fmt.Fprintf(os.Stderr, helpstring)
+	os.Exit(2)
+}
+
+func main() {
+	if os.Getenv("GOMAXPROCS") == "" {
+		// Use all available cores if not otherwise specified
+		runtime.GOMAXPROCS(runtime.NumCPU())
+	}
+
+	flag.Usage = usage
+	flag.Parse()
+
+	location := flag.Arg(0)
+	if len(location) == 0 {
+		flag.Usage()
+	}
+
+	chann := goWalk(location)
+
+	exitCode := 0
+
+	for msg := range chann {
+		fmt.Println(msg)
+		exitCode = 1
+	}
+
+	os.Exit(exitCode)
+}

--- a/tools/lint/mdlint/mdlint_test.go
+++ b/tools/lint/mdlint/mdlint_test.go
@@ -1,49 +1,11 @@
-package main
+package mdlint
 
 import (
+	"../mdlint"
 	"bufio"
-	"fmt"
-	"io"
 	"strings"
 	"testing"
 )
-
-type Stack struct {
-	top  *Element
-	size int
-}
-
-type Element struct {
-	value interface{}
-	next  *Element
-}
-
-// NewStack returns a new stack.
-func NewStack() *Stack {
-	return &Stack{}
-}
-
-// Return the stack's length
-func (s *Stack) Len() int {
-	return s.size
-}
-
-// Push a new element onto the stack
-func (s *Stack) Push(value interface{}) {
-	s.top = &Element{value, s.top}
-	s.size++
-}
-
-// Remove the top element from the stack and return its value
-// If the stack is empty, return nil
-func (s *Stack) Pop() (value interface{}) {
-	if s.size > 0 {
-		value, s.top = s.top.value, s.top.next
-		s.size--
-		return
-	}
-	return nil
-}
 
 func TestEmptyString(t *testing.T) {
 	collector := goLint("")
@@ -152,73 +114,7 @@ func goLint(markdown string) chan string {
 	go func() {
 		defer close(collector)
 		reader := bufio.NewReader(strings.NewReader(markdown))
-		Lint(reader, "test.md", collector)
+		mdlint.Lint(reader, "test.md", collector)
 	}()
 	return collector
-}
-
-func Lint(reader *bufio.Reader, path string, chann chan<- string) {
-	// Stack for parsing each, to get the line number where it was encountered
-	brackets, parens := NewStack(), NewStack()
-	line := 1
-	enDashes := make(map[int]int)
-
-	// Parse the file
-	for {
-		r, _, err := reader.ReadRune()
-
-		if err != nil {
-			if err != io.EOF {
-				chann <- fmt.Sprintf("Error reading from %s - %s", path, err)
-			}
-			break
-		}
-
-		switch r {
-		case '[':
-			brackets.Push(line)
-		case ']':
-			top := brackets.Pop()
-			if top == nil {
-				chann <- fmt.Sprintf("Bad Markdown URL in %s - extra closing bracket on line %d", path, line)
-			}
-		case '(':
-			parens.Push(line)
-		case ')':
-			top := parens.Pop()
-			if top == nil {
-				chann <- fmt.Sprintf("Bad Markdown URL in %s - extra closing parenthesis on line %d", path, line)
-			}
-		case '–':
-			enDashes[line]++
-		case '\n':
-			line++
-		}
-	}
-
-	checkHanging := func(stack *Stack, character string) {
-		results := make([]interface{}, stack.Len())
-		i := 0
-		for top := stack.Pop(); top != nil; top = stack.Pop() {
-			results[i] = top
-			i++
-		}
-
-		// Reverse the results, since we used a LIFO data structure to capture them
-		for i, j := 0, len(results)-1; i < j; i, j = i+1, j-1 {
-			results[i], results[j] = results[j], results[i]
-		}
-
-		for _, line := range results {
-			chann <- fmt.Sprintf("Bad Markdown URL in %s - extra opening %s on line %d", path, character, line)
-		}
-	}
-
-	// Check the results and accumulate any problems
-	checkHanging(brackets, "bracket")
-	checkHanging(parens, "parenthesis")
-
-	for line, _ := range enDashes {
-		chann <- fmt.Sprintf("literal en dash at %s:%d - please use -- instead", path, line)
-	}
 }


### PR DESCRIPTION
- Move into tools directory
- Put linting into new go package mdlint
- Remove duplication between implementation, tests and client usage
- Use relative import paths
