### PR TITLE
Add vendor directory to Jekyll's exclude list

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,6 +20,7 @@ exclude:
   - lint.go
   - README.md
   - tools
+  - vendor
 
 maruku:
   use_tex:    false


### PR DESCRIPTION
When using this app with Jekyll 1.2.1, `jekyll serve --watch` complains that the site could not be built because `0000-00-00-welcome-to-jekyll.markdown.erb` does not have a valid date, and therefore is not syntactically valid. This occurs because the Gemspec file (`vendor/gems/ruby/1.9.1/gems/jekyll-1.2.1/jekyll.gemspec`) checks that it exists and is valid. This fix adds the `vendor` directory to Jekyll's exclude list in `_config.yml`. Jekyll serving then works fine without any issues.

I'm opening this pull request for comments.
