### PR TITLE
Add more help to errors when linting

### DIFF
--- a/tools/lint/lint.go
+++ b/tools/lint/lint.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 )
 
-func goWalk(location string) chan string {
-	chann := make(chan string) // unbuffered channel of synchronous error messages
+func goWalk(location string) chan error {
+	chann := make(chan error) // unbuffered channel of synchronous error messages
 
 	go func() {
 		// Once we've walked all the files, close this channel to avoid deadlocks
@@ -74,8 +74,8 @@ func main() {
 
 	exitCode := 0
 
-	for msg := range chann {
-		fmt.Println(msg)
+	for err := range chann {
+		fmt.Println(err)
 		exitCode = 1
 	}
 

--- a/tools/lint/mdlint/mdlint.go
+++ b/tools/lint/mdlint/mdlint.go
@@ -3,13 +3,19 @@ package mdlint
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"io"
+	"log"
+	"os"
+	"strings"
+	"unicode/utf8"
 )
 
-type Position struct {
-	line   int
-	column int
+type SyntaxError struct {
+	line     int
+	column   int
+	position int64
 }
 
 type Stack struct {
@@ -49,40 +55,44 @@ func (s *Stack) Pop() (value interface{}) {
 	return nil
 }
 
-func Lint(reader *bufio.Reader, path string, chann chan<- string) {
+func Lint(reader *bufio.Reader, path string, chann chan<- error) {
 	// Stack for parsing each, to get the line number where it was encountered
 	brackets, parens := NewStack(), NewStack()
 	line := 1
 	column := 1
 	enDashes := make(map[int]int)
+	var pos int64 = 0
 
 	// Parse the file
 	for {
-		r, _, err := reader.ReadRune()
+		r, size, err := reader.ReadRune()
+		pos += int64(size)
 
 		if err != nil {
 			if err != io.EOF {
-				chann <- fmt.Sprintf("Error reading from %s - %s", path, err)
+				chann <- fmt.Errorf("Error reading from %s - %s", path, err)
 			}
 			break
 		}
 
 		switch r {
 		case '[':
-			brackets.Push(Position{line, column})
+			brackets.Push(SyntaxError{line, column, pos})
 		case ']':
 			top := brackets.Pop()
 			if top == nil {
-				chann <- fmt.Sprintf(`Bad Markdown URL in %s:
+				basicError := fmt.Errorf(`Bad Markdown URL in %s:
 	extra closing bracket at line %d, column %d`, path, line, column)
+				chann <- usefulError(path, pos, basicError)
 			}
 		case '(':
-			parens.Push(Position{line, column})
+			parens.Push(SyntaxError{line, column, pos})
 		case ')':
 			top := parens.Pop()
 			if top == nil {
-				chann <- fmt.Sprintf(`Bad Markdown URL in %s:
+				basicError := fmt.Errorf(`Bad Markdown URL in %s:
 	extra closing parenthesis at line %d, column %d`, path, line, column)
+				chann <- usefulError(path, pos, basicError)
 			}
 		case '–':
 			enDashes[line]++
@@ -99,25 +109,78 @@ func Lint(reader *bufio.Reader, path string, chann chan<- string) {
 	checkHanging(parens, "parenthesis", chann, path)
 
 	for line, _ := range enDashes {
-		chann <- fmt.Sprintf("literal en dash at %s:%d - please use -- instead", path, line)
+		chann <- fmt.Errorf("literal en dash at %s:%d - please use -- instead", path, line)
 	}
 }
 
-func checkHanging(stack *Stack, character string, chann chan <- string, path string) {
-		results := make([]Position, stack.Len())
-		i := 0
-		for top := stack.Pop(); top != nil; top = stack.Pop() {
-			results[i] = top.(Position)
-			i++
-		}
+func checkHanging(stack *Stack, character string, chann chan<- error, path string) {
+	results := make([]SyntaxError, stack.Len())
+	i := 0
+	for top := stack.Pop(); top != nil; top = stack.Pop() {
+		results[i] = top.(SyntaxError)
+		i++
+	}
 
-		// Reverse the results, since we used a LIFO data structure to capture them
-		for i, j := 0, len(results)-1; i < j; i, j = i+1, j-1 {
-			results[i], results[j] = results[j], results[i]
-		}
+	// Reverse the results, since we used a LIFO data structure to capture them
+	for i, j := 0, len(results)-1; i < j; i, j = i+1, j-1 {
+		results[i], results[j] = results[j], results[i]
+	}
 
-		for _, position := range results {
-			chann <- fmt.Sprintf(`Bad Markdown URL in %s:
-	extra opening %s at line %d, column %d`, path, character, position.line, position.column)
+	for _, syntaxError := range results {
+		basicError := fmt.Errorf(`Bad Markdown URL in %s:
+	extra opening %s at line %d, column %d`, path, character, syntaxError.line, syntaxError.column)
+		chann <- usefulError(path, syntaxError.position, basicError)
+	}
+}
+
+func highlightError(f io.Reader, pos int64) (line, col int, highlight string) {
+	line = 1
+	br := bufio.NewReader(f)
+	lastLine := ""
+	thisLine := new(bytes.Buffer)
+	for n := int64(0); n < pos; n++ {
+		b, err := br.ReadByte()
+		if err != nil {
+			break
+		}
+		if b == '\n' {
+			lastLine = thisLine.String()
+			thisLine.Reset()
+			line++
+			col = 1
+		} else {
+			if utf8.RuneStart(b) {
+				col++
+			}
+			thisLine.WriteByte(b)
 		}
 	}
+	if line > 1 {
+		highlight += fmt.Sprintf("%5d: %s\n", line-1, lastLine)
+	}
+	highlight += fmt.Sprintf("%5d: %s\n", line, thisLine.String())
+	highlight += fmt.Sprintf("%s^\n", strings.Repeat(" ", col+5))
+	return
+}
+
+func usefulError(path string, pos int64, basicError error) error {
+	f, err := os.Open(path)
+
+	if err != nil {
+		// We don't have a file that we can read? Maybe just operating on a buffer.
+		return basicError
+	}
+
+	defer f.Close()
+
+	if _, serr := f.Seek(0, os.SEEK_SET); serr != nil {
+		log.Fatalf("seek error: %v", serr)
+	}
+
+	line, col, highlight := highlightError(f, pos)
+	extra := fmt.Sprintf(":\nError at line %d, column %d (file offset %d):\n%s",
+		line, col, pos, highlight)
+
+	return fmt.Errorf("Error parsing Markdown in %s%s\n",
+		f.Name(), extra)
+}

--- a/tools/lint/mdlint/mdlint_test.go
+++ b/tools/lint/mdlint/mdlint_test.go
@@ -88,29 +88,29 @@ where in the file you should be looking to fix problems
 	assertChannelIsEmpty(t, collector)
 }
 
-func assertPrefix(t *testing.T, problem string, prefix string) {
-	if !strings.HasPrefix(problem, prefix) {
+func assertPrefix(t *testing.T, problem error, prefix string) {
+	if !strings.HasPrefix(problem.Error(), prefix) {
 		t.Log(problem)
 		t.Fail()
 	}
 }
 
-func assertSuffix(t *testing.T, problem string, suffix string) {
-	if !strings.HasSuffix(problem, suffix) {
+func assertSuffix(t *testing.T, problem error, suffix string) {
+	if !strings.HasSuffix(problem.Error(), suffix) {
 		t.Log(problem)
 		t.Fail()
 	}
 }
 
-func assertChannelIsEmpty(t *testing.T, chann chan string) {
+func assertChannelIsEmpty(t *testing.T, chann chan error) {
 	for e := range chann {
 		t.Log(e)
 		t.Fail()
 	}
 }
 
-func goLint(markdown string) chan string {
-	collector := make(chan string)
+func goLint(markdown string) chan error {
+	collector := make(chan error)
 	go func() {
 		defer close(collector)
 		reader := bufio.NewReader(strings.NewReader(markdown))


### PR DESCRIPTION
```
> make lint go run tools/lint/lint.go service-manual error parsing Markdown in
service-manual/agile/features-of-agile.md: Error at line 32, column 7 (file
offset 898):
  31:
  32: Each [
           ^
```
