### PR TITLE
Exclude toolkit documentation from Jekyll

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,6 +17,7 @@ exclude:
   - Gemfile.lock
   - Makefile
   - README.md
+  - /service-manual/assets/toolkit/*.md
   - /tools
   - /tmp
   - /vendor


### PR DESCRIPTION
There's no need to compile markdown files from the toolkit root directory into the service manual.

This is a regression from #417 (@jabley).
