### PR TITLE
Correct DbD wording

### DIFF
--- a/service-manual/digital-by-default/index.md
+++ b/service-manual/digital-by-default/index.md
@@ -146,7 +146,7 @@ breadcrumbs:
     </div>
   </li>
   <li id="criterion-13">
-    <div class="point">Build a service consistent with the user experience of the rest of GOV.UK by using the <a href="/service-manual/user-centred-design/resources/patterns/index.html">design patterns</a>.</div>
+    <div class="point">Build a service consistent with the user experience of the rest of GOV.UK by using the <a href="/service-manual/user-centred-design/resources/patterns/index.html">design patterns</a> and the <a href="/design-principles/style-guide">style guide</a>.</div>
     <div class="guidance">
       <p>Related guides</p>
       <ul>


### PR DESCRIPTION
The content that was previously linked to was removed in 0178f4ea0d35a6489586a16944e548bbaa7d15a4. This change also amended the
service standard wording as a result of removing the linked content.

We are not supposed to change wording of the service standard. Any
changes need to be cleared with the service standard team.

Added the words back, and now linking to the content style guide for
GOV.UK.
