### PR TITLE
Add link-checking to travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_script:
   - git submodule update --init
   - bundle exec jekyll build
 script:
-  - make lint
+  - make lint links
   - bundle exec ruby ./tools/spellcheck/branch-spellcheck.rb $TRAVIS_BRANCH
 branches:
   except:


### PR DESCRIPTION
I would like confidence that any changes do not introduce broken links
to other parts of the service manual.
