### PR TITLE
ID Assurance is now known as GOV.UK Verify

### DIFF
--- a/service-manual/assisted-digital/action-plan.md
+++ b/service-manual/assisted-digital/action-plan.md
@@ -81,7 +81,7 @@ You’ll need to continue [developing user personas and user journeys](/service-
 * organisations who support people offline to access services
 * organisations who are already providing formal and informal support to your users
 
-You’ll need to put suitable plans in place to support your assisted digital users if your service requires [Identity Assurance](/service-manual/identity-assurance).
+You’ll need to put suitable plans in place to support your assisted digital users if your service requires [GOV.UK Verify](/service-manual/identity-assurance).
 
 You should also consider any impacts on or overlaps with other central government transactions, to make sure that the user journey is consistent and joined up across services, where relevant.
 

--- a/service-manual/assisted-digital/index.md
+++ b/service-manual/assisted-digital/index.md
@@ -116,4 +116,4 @@ Services may have existing contracts for providing outsourced assisted digital. 
 
 ## Authenticating user identity
 
-Services that include a requirement for users to authenticate their identity before undertaking a digital transaction should refer to GDS’s [Identity Assurance](/service-manual/identity-assurance) guidance and [contact](mailto:janet.hughes@digital.cabinet-office.gov.uk)  the Identity Assurance (IDA) team at GDS at the earliest opportunity. GDS are developing IDA as the default identity assurance platform within government digital services. 
+Services that include a requirement for users to authenticate their identity before undertaking a digital transaction should refer to GDS’s [GOV.UK Verify](/service-manual/identity-assurance) guidance and [contact](mailto:janet.hughes@digital.cabinet-office.gov.uk)  the GOV.UK Verify team at GDS at the earliest opportunity. GDS are developing IDA as the default GOV.UK Verify platform within government digital services. 

--- a/service-manual/identity-assurance/index.md
+++ b/service-manual/identity-assurance/index.md
@@ -1,6 +1,6 @@
 ---
 layout: detailed-guidance
-title: Identity assurance guidance
+title: GOV.UK Verify guidance
 subtitle: For government service providers
 category: identity-assurance
 type: guide
@@ -23,25 +23,25 @@ breadcrumbs:
 
 Users of digital government services need to be able to sign in securely and conveniently to access services and records, and be confident that their data is secure and their privacy protected.
 
-Identity assurance is the way that users of digital services can sign in securely to digital services, and digital services can be confident that users are who they say they are. A good background description can be found [on this blog post](https://gds.blog.gov.uk/2014/01/23/what-is-identity-assurance/).
+GOV.UK Verify is the way that users of digital services can sign in securely to digital services, and digital services can be confident that users are who they say they are. A good background description can be found [on this blog post](https://gds.blog.gov.uk/2014/01/23/what-is-identity-assurance/).
 
 Service providers can be assured they’re providing their service to the right individual or business after matching an assured identity to their own records.
 
-This guidance is for government digital service providers that need to use the identity assurance service. Service providers are referred to as ‘relying parties’ to avoid confusion between those providing the government service to the user and those providing the identity service to the user.
+This guidance is for government digital service providers that need to use the GOV.UK Verify service. Service providers are referred to as ‘relying parties’ to avoid confusion between those providing the government service to the user and those providing the identity service to the user.
 
-The guidance gives an overview of the identity assurance service and explains what relying parties will need to do to prepare to start using the identity assurance service.
+The guidance gives an overview of the GOV.UK Verify service and explains what relying parties will need to do to prepare to start using the GOV.UK Verify service.
 
-Relying parties that need to use the identity assurance service will need to:
+Relying parties that need to use the GOV.UK Verify service will need to:
 
-- assess the level and type of identity assurance they require
+- assess the level and type of GOV.UK Verify they require
 - build a service to request and consume Security Assertion Markup Language (SAML) identity assertions
 - build a matching service to match assured identities to their own records
 
-## How the identity assurance service works
+## How the GOV.UK Verify service works
 
 ### 1. User is directed to the hub to sign in
 
-When users try to use a service provided by a relying party, they will be directed to the identity assurance hub at the point in the user journey where the relying party needs to know who they are.
+When users try to use a service provided by a relying party, they will be directed to the GOV.UK Verify hub at the point in the user journey where the relying party needs to know who they are.
 
 The hub manages communications between users, relying parties and identity providers. It makes sure that users can assert their identities securely and safely, and that relying parties can be confident that users are who they say they are.
 
@@ -68,26 +68,26 @@ The hub sends the matching dataset to the relying party’s matching service. Re
 * managing the risk of incorrect matching
 * handling the case of multiple (many records found) or no matches (user not found)
 
-Once matching has taken place, the user is directed to the correct record within the relying party’s service. The identity assurance team can advise services on how to develop their matching service.
+Once matching has taken place, the user is directed to the correct record within the relying party’s service. The GOV.UK Verify team can advise services on how to develop their matching service.
 
 ### 4. User is given access to their account within the service they want to use
 
-Once a user has registered with an identity provider, they will be able to sign in to all digital services that use the identity assurance service and require the same level of assurance, using credentials provided to them by their identity provider.
+Once a user has registered with an identity provider, they will be able to sign in to all digital services that use the GOV.UK Verify service and require the same level of assurance, using credentials provided to them by their identity provider.
 
-The first government services to start using the identity assurance service will connect to the hub in early 2014. Each other service will connect at a time agreed with the programme team. Relying parties that have identity assurance requirements should contact the identity assurance programme team to start planning their connection to the service.
+The first government services to start using the GOV.UK Verify service will connect to the hub in early 2014. Each other service will connect at a time agreed with the programme team. Relying parties that have GOV.UK Verify requirements should contact the GOV.UK Verify programme team to start planning their connection to the service.
 
-Read the [blog posts from the identity assurance programme team](https://identityassurance.blog.gov.uk/) for more information and updates about the development of the identity assurance service,
+Read the [blog posts from the GOV.UK Verify programme team](https://identityassurance.blog.gov.uk/) for more information and updates about the development of the identity assurance service,
 
-## How to assess the identity assurance requirements of a digital service
+## How to assess the GOV.UK Verify requirements of a digital service
 
-Relying parties can assess their identity assurance needs by using [guidance published by the Cabinet Office](https://www.gov.uk/government/collections/identity-assurance-enabling-trusted-transactions). Each relying party must carry out a risk assessment of their digital service, using [Good Practice Guide 43: Requirements for secure delivery of online public services][gpg43].
+Relying parties can assess their GOV.UK Verify needs by using [guidance published by the Cabinet Office](https://www.gov.uk/government/collections/identity-assurance-enabling-trusted-transactions). Each relying party must carry out a risk assessment of their digital service, using [Good Practice Guide 43: Requirements for secure delivery of online public services][gpg43].
 
 The identity’s ‘level of assurance’ is the degree of confidence the relying party requires that a user is who they say they are:
 
 * level of assurance 1 is used when a relying party needs to know that it is the same user returning to the service but does not need to know who that user is
 * level of assurance 2 is used when a relying party needs to know on the balance of probabilities who the user is and that that they are a real person
 * level of assurance 3 is used when a relying party needs to know beyond reasonable doubt who the user is and that that they are a real person
-* level of assurance 4 is as level of assurance 3, but with a biometric profile captured at the point of registration. This level is not within the scope of this stage in the identity assurance programme
+* level of assurance 4 is as level of assurance 3, but with a biometric profile captured at the point of registration. This level is not within the scope of this stage in the GOV.UK Verify programme
 
 The different levels of assurance available and how they are reached are defined by the Cabinet Office's good practice guides. Each relying party must determine the level of assurance required for each digital service:
 
@@ -100,20 +100,20 @@ The different levels of assurance available and how they are reached are defined
 [gpg45]: https://www.gov.uk/government/publications/identity-proofing-and-verification-of-an-individual
 [gpg46]: https://www.gov.uk/government/publications/identity-assurance-organisation-identity
 
-## How to work with the identity assurance programme to prepare to use identity assurance
+## How to work with the GOV.UK Verify programme to prepare to use GOV.UK Verify
 
 Each relying party will need to go through the programme’s induction process. This process consists of 4 structured stages:
 
-1. Introduction -- identify a need for identity assurance.
-2. Needs Analysis -- identify the service’s identity assurance requirements (levels and types), users and dependencies. Agree a provisional date for connection to hub.
+1. Introduction -- identify a need for GOV.UK Verify.
+2. Needs Analysis -- identify the service’s GOV.UK Verify requirements (levels and types), users and dependencies. Agree a provisional date for connection to hub.
 3. Planning -- complete a readiness assessment. Agree a detailed plan setting out what the service and GDS will each do and when. Get internal approvals within GDS and the relying party's organisation.
-4. Connect to hub -- agree a memorandum of understanding between the Identity Assurance Programme and the department responsible for the service.
+4. Connect to hub -- agree a memorandum of understanding between the GOV.UK Verify Programme and the department responsible for the service.
 
-Government providers of digital services that want to find out more about identity assurance, with a view to becoming relying parties, should contact [Janet Hughes](mailto:janet.hughes@digital.cabinet-office.gov.uk).
+Government providers of digital services that want to find out more about GOV.UK Verify, with a view to becoming relying parties, should contact [Janet Hughes](mailto:janet.hughes@digital.cabinet-office.gov.uk).
 
 ## How to match assured identities to service records
 
-Each relying party will need to set up a matching service that can accept digital assertions of identity and match them to their internally held records. This process makes sure they can use the identity assertions provided by the identity assurance service.
+Each relying party will need to set up a matching service that can accept digital assertions of identity and match them to their internally held records. This process makes sure they can use the identity assertions provided by the GOV.UK Verify service.
 
 Matching assured identities to the records held by relying parties is likely to be complicated -- each relying party will need to establish the most efficient and effective way of doing this depending on the quality of its data and how it’s stored and managed.
 

--- a/service-manual/making-software/logins.md
+++ b/service-manual/making-software/logins.md
@@ -62,9 +62,9 @@ It's probably safe to carry on if you're building a service for a small number o
   * unusually high numbers of failed login attempts over a short period of time
   * a sequence of failed logins on a given account over a long period of time
 * separate user data from other data you hold to avoid collecting a large amount of identifiable information
-* swap to a new identity system, like the [identity assurance](/service-manual/identity-assurance) scheme, without invasive changes to the rest of your codebase
+* swap to a new identity system, like the [GOV.UK Verify](/service-manual/identity-assurance) scheme, without invasive changes to the rest of your codebase
 
-Read the [advice published by the identity assurance team](/service-manual/identity-assurance) if you need to:
+Read the [advice published by the GOV.UK Verify](/service-manual/identity-assurance) if you need to:
 
 * build a system for a broad range of citizens and businesses
 * do sophisticated matching with other systems so you can build confidence in the identity of your users

--- a/service-manual/technology/architecture.md
+++ b/service-manual/technology/architecture.md
@@ -92,7 +92,7 @@ Products and services are the things that users engage with to find information 
 
 Platforms provide a set of open interfaces, protocols, data formats and tools that enable software developers to rapidly provide products and services.
 
-Examples of platforms are the GOV.UK publishing platform, the Performance Platform, and the [identity assurance](/service-manual/identity-assurance) platform -- they are not things like ‘Windows Server’ or ‘Linux Server’.
+Examples of platforms are the GOV.UK publishing platform, the Performance Platform, and the [GOV.UK Verify](/service-manual/identity-assurance) platform -- they are not things like ‘Windows Server’ or ‘Linux Server’.
 
 Platforms should be kept as simple as possible, but designed to have no barriers to scaling up and scaling out. New features should be added only when required by new product needs -- platforms emerge from the demands of products rather than being driven by top-down architectural process.
 

--- a/service-manual/technology/index.md
+++ b/service-manual/technology/index.md
@@ -51,6 +51,6 @@ Understanding the interoperability of services and devices is crucial to being a
 * understand the [architecture](/service-manual/technology/architecture.html) of services and technology across team, departments and government
 * provide [end user devices](/service-manual/technology/end-user-devices.html) which meet user needs
 * have a good understanding of what effective [service integration](/service-manual/technology/service-integration.html) looks like
-* understand the role of [identity assurance](/service-manual/identity-assurance/index.html) when providing services to citizens
+* understand the role of [GOV.UK Verify](/service-manual/identity-assurance/index.html) when providing services to citizens
 
 *[CTOs]: Chief Technology Officers

--- a/service-manual/technology/spending-controls.md
+++ b/service-manual/technology/spending-controls.md
@@ -30,7 +30,7 @@ The government's [Spend Controls](https://www.gov.uk/government/publications/cab
 * strategic supplier management, including disputes
 * commercial models
 * ICT
-* Digital Service Delivery (including [identity assurance](/service-manual/identity-assurance))
+* Digital Service Delivery (including [GOV.UK Verify](/service-manual/identity-assurance))
 * external recruitment
 * consultancy
 * redundancy and compensation

--- a/service-manual/the-team/learning-and-development/open-programme.md
+++ b/service-manual/the-team/learning-and-development/open-programme.md
@@ -99,7 +99,7 @@ Using data to inform decision-making is vital to the development of your service
 
 ##Identity assured
 
-We need to know that users of digital services are who they say they are. In this session, you will learn how the Identity Assurance Programme is:
+We need to know that users of digital services are who they say they are. In this session, you will learn how the GOV.UK Verify Programme is:
 
 * creating a market so that users can choose from a number of identity providers
 
@@ -107,7 +107,7 @@ We need to know that users of digital services are who they say they are. In thi
 
 * building and running the hub that connects services to identity providers
 
-* working with departments and agencies to identify their services’ identity assurance requirements and plan their transition to using the identity assurance service
+* working with departments and agencies to identify their services’ GOV.UK Verify requirements and plan their transition to using the GOV.UK Verify service
 
 ##Procure to improve
 


### PR DESCRIPTION
Replace 'identity assurance'  with GOV.UK Verify
