### PR TITLE
Add future browsers

### DIFF
--- a/service-manual/user-centred-design/browsers-and-devices.md
+++ b/service-manual/user-centred-design/browsers-and-devices.md
@@ -60,7 +60,7 @@ Two distinct levels of support are given and denoted next to each browser. Where
     <td>Mozilla Firefox (latest version)</td><td>Compliant</td>
   </tr>
   <tr>
-    <th scope="row" rowspan="3">Mac OS X</th><td>Safari 7</td><td>Compliant</td>
+    <th scope="row" rowspan="3">Mac OS X</th><td>Safari 7+</td><td>Compliant</td>
   </tr>
   <tr>
     <td>Google Chrome (latest version)</td><td>Compliant</td>
@@ -79,7 +79,7 @@ Two distinct levels of support are given and denoted next to each browser. Where
     </tr>
   </thead>
   <tr>
-    <th scope="row" rowspan="4">iOS</th><td rowspan="2">7</td><td>Mobile Safari</td><td>Compliant</td>
+    <th scope="row" rowspan="4">iOS</th><td rowspan="2">7+</td><td>Mobile Safari</td><td>Compliant</td>
   </tr>
   <tr>
     <td>Google Chrome</td><td>Compliant</td>
@@ -100,7 +100,7 @@ Two distinct levels of support are given and denoted next to each browser. Where
     <td>2.3</td><td>Android Browser</td><td>Functional</td>
   </tr>
   <tr>
-    <th scope="row">Windows Phone</th><td>8</td><td>Internet Explorer 10</td><td>Functional</td>
+    <th scope="row">Windows Phone</th><td>8</td><td>Internet Explorer 10+</td><td>Functional</td>
   </tr>
   <tr>
     <th scope="col">BlackBerry</th><td>7.1</td><td>BlackBerry Browser</td><td>Functional</td>


### PR DESCRIPTION
So that we don't have to add each browser version add assumption that
all future should be supported. We can still drop older versions when needed.
