### PR TITLE
Updating the footer to include change to /browse/housing category link

### DIFF
--- a/_includes/layouts/_footer_top.html
+++ b/_includes/layouts/_footer_top.html
@@ -14,7 +14,7 @@
     <ul>
       <li><a href="/browse/employing-people">Employing people</a></li>
       <li><a href="/browse/environment-countryside">Environment and countryside</a></li>
-      <li><a href="/browse/housing">Housing and local services</a></li>
+      <li><a href="/browse/housing-local-services">Housing and local services</a></li>
       <li><a href="/browse/tax">Money and tax</a></li>
       <li><a href="/browse/abroad">Passports, travel and living abroad</a></li>
       <li><a href="/visas-immigration">Visas and immigration</a></li>


### PR DESCRIPTION
The browse/housing category has been renamed browse/housing-local-services.
