### PR TITLE
CSS should be compiled as part of travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_script:
 script:
   - make lint links
   - bundle exec ruby ./tools/spellcheck/branch-spellcheck.rb $TRAVIS_BRANCH
+  - ./compile.sh
 branches:
   except:
     - master

--- a/compile.sh
+++ b/compile.sh
@@ -51,6 +51,10 @@ check_css_compiled ./_site/service-manual/assets/stylesheets/main-ie6.css
 check_css_compiled ./_site/service-manual/assets/stylesheets/main-ie7.css
 check_css_compiled ./_site/service-manual/assets/stylesheets/main-ie8.css
 
+if [ -n "$TRAVIS" ]; then
+  exit 0
+fi
+
 echo "Copying the compiled manual to $GUIDANCE_PATH"
 
 cp -R ./_site/service-manual $GUIDANCE_PATH


### PR DESCRIPTION
Toolkit usage was broken recently and this wasn’t picked up when the
change happened.
