### PR TITLE
Update links to the GOV.UK style guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,5 +12,5 @@ Once guidance has been submitted it will stay open as a pull request for a few d
 Remember to:
 
 * [write helpful commit messages](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)
-* [check the GDS style guide](https://www.gov.uk/design-principles/style-guide) for tips on how to write to our standard
+* check the GOV.UK [style guide](/guidance/style-guide/a-to-z-of-gov-uk-style) and [content design guidance](/guidance/content-design/writing-for-gov-uk#writing-to-govuk-style) for tips on how to write to our standard
 * make sure that new guidance has been shared with the relevant people before being submitted

--- a/_layouts/role-index-content-designer.html
+++ b/_layouts/role-index-content-designer.html
@@ -22,8 +22,8 @@ section_class: wide role-index
 <div class="article-container">
   <div class="primary-links">
     <div class="hero link-list">
-        <a href="https://www.gov.uk/design-principles/style-guide">
-          <h3>GOV.UK style guide</h3>
+        <a href="/guidance/content-design">
+          <h3>GOV.UK content design</h3>
           <p>How to write for GOV.UK</p>
         </a>
     </div>

--- a/service-manual/communications/blogs.md
+++ b/service-manual/communications/blogs.md
@@ -16,7 +16,7 @@ breadcrumbs:
     url: /service-manual/communications
 ---
 
-Blogs are a simple, effective way of keeping a record of the work a team is doing on a service. 
+Blogs are a simple, effective way of keeping a record of the work a team is doing on a service.
 
 Updates can be as short as you like, allowing you to tell readers about subtle changes to a service’s design or new features added to a tool, while also offering you a platform for longer pieces of writing that describe significant changes to policy or approach.
 
@@ -42,20 +42,20 @@ Though the frequency with which you blog will often vary you should aim to publi
 
 A well-chosen illustration or photo can add important context or information for your readers. The GOV.UK blogging platform is fairly flexible. You can embed tweets, slide decks and videos as well as images, all media that make your message just [a little bit easier to comprehend](https://insidegovuk.blog.gov.uk/2013/09/11/prototyping-browse-and-navigation/).
 
-##Use the style guide...
+##Use the style guidance...
 
-[The GOV.UK style guide](https://www.gov.uk/design-principles/style-guide) is an invaluable tools for writers. It’s full of carefully researched tips for clear, concise prose which seeks to make your writing easier to understand.
+The GOV.UK [content design guidance](/guidance/content-design/blogging#style-and-tone-of-voice) is an invaluable tool for writers. They’re full of carefully researched tips for clear, concise prose which seeks to make your writing easier to understand.
 
-In particular, make use of subheadings and bullet points within your blog posts to make them quicker to read. And make use of the 'words to avoid' list -- it’s there to make sure writers stay clear no matter the audience.
+In particular, make use of subheadings and bullet points within your blog posts to make them quicker to read. And make use of the [‘words to avoid’ list](/guidance/style-guide/a-to-z-of-gov-uk-style#words-to-avoid) -- it’s there to make sure writers stay clear no matter the audience.
 
 ##...but remember you’re a person
 
-The style guide doesn’t mean you can’t be warm, candid or personal. You should be all of these things. 
+The style guide doesn’t mean you can’t be warm, candid or personal. You should be all of these things.
 
 It’s important that you’re accountable for the things you write. If your name appears on a post then you should be prepared to respond to comments and engage in dialogue both on your blog and on other social networks. It’ll improve your work, and ultimately improve the experience for your users
 
 ##Always get someone to read it first
 
-It’s a given that writers will be professional and mindful of things like the [Civil Service Code](http://www.civilservice.gov.uk/about/values) when they blog, but you should always get someone to read your work over before you hit PUBLISH. 
+It’s a given that writers will be professional and mindful of things like the [Civil Service Code](http://www.civilservice.gov.uk/about/values) when they blog, but you should always get someone to read your work over before you hit PUBLISH.
 
-For starters, they’ll probably spot a few mistake that have slipped your notice, but they might also be able to offer a different perspective on the things you’re writing about. 
+For starters, they’ll probably spot a few mistake that have slipped your notice, but they might also be able to offer a different perspective on the things you’re writing about.

--- a/service-manual/digital-by-default/index.md
+++ b/service-manual/digital-by-default/index.md
@@ -164,7 +164,7 @@ breadcrumbs:
     </div>
   </li>
   <li id="criterion-13">
-    <div class="point">Build a service consistent with the user experience of the rest of GOV.UK by using the <a href="/service-manual/user-centred-design/resources/patterns/index.html">design patterns</a> and the <a href="/design-principles/style-guide">style guide</a>.</div>
+    <div class="point">Build a service consistent with the user experience of the rest of GOV.UK by using the <a href="/service-manual/user-centred-design/resources/patterns/index.html">design patterns</a> and the <a href="/government-digital-guidance/content-publishing">style guide</a>.</div>
     <div class="guidance">
       <p>Related guides</p>
       <ul>
@@ -303,4 +303,3 @@ breadcrumbs:
 </ol>
 
 <p class="print-footer"><span>Find out more at www.gov.uk/service-manual/digital-by-default</span></p>
-

--- a/service-manual/the-team/content-designer.md
+++ b/service-manual/the-team/content-designer.md
@@ -43,14 +43,14 @@ Content designers must be able to:
   - analytics data both from the site and from search engines
 - gain an in-depth knowledge of a wide range of subjects -- so they can make informed decisions about the best way to present information to users
 - develop content plans and strategies -- high-level plans showing how the identified user needs will be met
-- write great content -- in [plain English](/design-principles/style-guide#writing-plain-english), optimised for the web and according to [house style](/design-principles/style-guide#style-guide)
+- [write great content](/guidance/content-design/writing-for-gov-uk) -- in [plain English](/guidance/content-design/writing-for-gov-uk#plain-english), optimised for the web and according to [house style](/guidance/style-guide/a-to-z-of-gov-uk-style)
 - edit content -- making sure the site remains accurate, relevant, current and optimised both for users and search engines
 - make tough decisions and work hard for the user -- grappling with complicated legislation and turning it into clear, clean, crisp web content (that still has enough depth to be useful)
 - work with developers and designers to [create better solutions](https://gds.blog.gov.uk/2012/11/05/tools-over-content/) -- for example, writing logic and content for [smart answers](https://gds.blog.gov.uk/2012/02/16/smart-answers-are-smart/)
 - understand and incorporate the results of [user testing](/service-manual/user-centred-design/user-research)
 - review the work of other editors -- to make sure consistency and excellence is maintained across the site
 - publish content -- using various systems
-- communicate the [principles of good content design](/design-principles/style-guide) to others in the organisation
+- communicate the [principles of good content design](/guidance/content-design/what-is-content-design) to others in the organisation
 - advocate for the user and act as a guardian for the site -- pushing back on change requests that don’t contribute to meeting user needs and incorporating change requests that do
 - build positive relationships with others inside the team and in the wider organisation
 - innovate and anticipate -- excellent content designers are excited about the possibilities of web content and contributing to the digital sector's future

--- a/service-manual/user-centred-design/how-users-read.md
+++ b/service-manual/user-centred-design/how-users-read.md
@@ -21,12 +21,12 @@ breadcrumbs:
     url: /service-manual/user-centred-design
 ---
 
-The [style guide](https://www.gov.uk/design-principles/style-guide) is set in best practice and relates to how users read. This is an explanation of some of our guidance and the reasons behind the rules.
+The [content design guidance](/guidance/content-design) and [style guide](/guidance/style-guide/a-to-z-of-gov-uk-style) are set in best practice and relate to how users read. This is an explanation of some of our guidance and the reasons behind the rules.
 
 ## Reading
 Users only really read 20 to 28% of a web page. Where users just want to complete a service as quickly as possible, there's added user impatience so you may find users skim words even more.
 
-[The content style guide](https://www.gov.uk/design-principles/style-guide) and [design patterns](/service-manual/user-centred-design/resources/patterns/index.html) give guidance on how to write. This page details why we do it.
+The [content design guidance](/guidance/content-design), [style guide](/guidance/style-guide/a-to-z-of-gov-uk-style) and [design patterns](https://www.gov.uk/service-manual/user-centred-design/resources/patterns/index.html) give guidance on how to write. This page details why we do it.
 
 All of this guidance is based on the learning skills of an average person in the UK, who has English as a first language.
 
@@ -55,7 +55,7 @@ Also, in modern usage it sounds like we're shouting. We are government. We shoul
 ## Plain English
 By the time you are 9, you're building up your ‘common words’. Your primary set is around 5,000 words in your vocabulary; your secondary set is around 10,000 words.
 
-These are words you use every day. They include a lot of [plain English](https://www.gov.uk/design-principles/style-guide#writing-plain-english) words, which is why we should be obsessed with them. These are words so easy to comprehend, you learn to read them quickly and then you stop reading and start recognising.
+These are words you use every day. They include a lot of [plain English](/guidance/content-design/writing-for-gov-uk#plain-english) words, which is why we should be obsessed with them. These are words so easy to comprehend, you learn to read them quickly and then you stop reading and start recognising.
 
 ## Context
 We explain all unusual terms on GOV.UK. This is because you can understand 6-letter words as easily as 2-letter words -- if they're in context.

--- a/service-manual/user-centred-design/print-forms.md
+++ b/service-manual/user-centred-design/print-forms.md
@@ -99,7 +99,7 @@ Get [an introduction to user research](/service-manual/user-centred-design/user-
 
 [Templates](#templates-and-examples) (based on the Lasting Power of Attorney application) created by teams across government will help you make easy-to-complete forms, but lots of the 'heavy-lifting' will be in making specialist terms and language accessible to the majority of users.
 
-Where specialist terms are unavoidable, or necessary, you'll need people who understand [how users read](/service-manual/user-centred-design/how-users-read) and how best to [write for government services](https://www.gov.uk/design-principles/style-guide/writing-for-govuk) when working on the design.
+Where specialist terms are unavoidable, or necessary, you'll need people who understand [how users read](/service-manual/user-centred-design/how-users-read) and how best to [write for government services](https://www.gov.uk/guidance/content-design/writing-for-gov-uk) when working on the design.
 
 Skilled content designers and copywriters will make forms -- whether online or in print -- simpler and clearer, improving the [completion rate](/service-manual/measurement/completion-rate.html) and [user satisfaction](/service-manual/measurement/user-satisfaction.html) in the process.
 


### PR DESCRIPTION
The GOV.UK style guide is now part of the new [content guidance](https://insidegovuk.blog.gov.uk/2014/10/07/content-guidance-now-in-one-place/).

The mappings have been done by the Depts & Policy content team.
