### PR TITLE
Stephen Kelly is no longer COO

### DIFF
--- a/service-manual/start/index.md
+++ b/service-manual/start/index.md
@@ -56,7 +56,8 @@ At SPRINT13, Minister for the Cabinet Office Francis Maude discussed the [curren
   <a href="https://www.youtube.com/watch?v=pa07ltj4K4w">Watch Francis Maude at SPRINT13</a>
 </figure>
 
-SPRINT 13 also saw a talk by Stephen Kelly, Chief Operating Officer UK government, in which he paints a picture of [what service redesign could mean for users](https://www.youtube.com/watch?v=X1A8cg__LpM).
+SPRINT 13 also saw a talk by [Stephen
+Kelly](https://www.gov.uk/government/people/stephen-kelly--2) in which he paints a picture of [what service redesign could mean for users](https://www.youtube.com/watch?v=X1A8cg__LpM).
 
 <figure class="media-player-wrapper video">
   <a href="https://www.youtube.com/watch?v=X1A8cg__LpM">Watch Stephen Kelly at SPRINT13</a>


### PR DESCRIPTION
But since GOV.UK should be a record of Government itself, we should still
reference him by pointing to his page on GOV.UK.