### PR TITLE
Update references to SSL to use TLS

### DIFF
--- a/service-manual/domain-names/https.md
+++ b/service-manual/domain-names/https.md
@@ -27,8 +27,8 @@ Many services will collect personal information from users. It’s very importan
 intercepted by malicious third parties as it travels over the Internet.
 
 Therefore, all services accessed through service.gov.uk domains (including APIs) MUST only be accessible through
-secure connections. For web-based services this means HTTPS only (often referred to by the acronyms TLS or SSL,
-which both refer to the protocol underpinning these secure connections). Services MUST NOT accept HTTP connections
+secure connections. For web-based services this means HTTPS only (often referred to by the acronym TLS,
+which refers to the protocol underpinning these secure connections). Services MUST NOT accept HTTP connections
 under any circumstances.
 
 ### Strict Transport Security
@@ -50,25 +50,25 @@ is configured correctly, you SHOULD increase the commitment to months or years:
 
     Strict-Transport-Security: max-age=31536000, includeSubDomains;
 
-### Verification of SSL Certificates
+### Verification of TLS Certificates
 
 In order to provide your service over HTTPS you will need to purchase a certificate (or certificates) from a
-recognised vendor. SSL vendors vary but regardless of which service you choose to use, you’ll need to validate
+recognised vendor. TLS vendors vary but regardless of which service you choose to use, you’ll need to validate
 with the vendor that you own the domain.
 
 The verification methods that are commonly in use (in order of preference) are:
 
-1. Create a file with a special code supplied by the SSL vendor on your website
-2. Create a special DNS record with a code supplied by the SSL vendor
+1. Create a file with a special code supplied by the TLS vendor on your website
+2. Create a special DNS record with a code supplied by the TLS vendor
 3. Sending an email to the owner of the service.gov.uk domain
 
 The least preferred method of sending an email to the domain owner relies on the GDS Infrastructure Team
 seeing the verification email and responding. If this is necessary, then first send an email to the address that
-you intend to use for verification from your own email address warning that an SSL verification is needed for
+you intend to use for verification from your own email address warning that a TLS verification is needed for
 your service.
 
 Your request should be sent to hostmaster@digital.cabinet-office.gov.uk, and
-should mention that an SSL verification email will be sent to them. It also helps if you include the domain name(s)
-to be secured and the name of the SSL certificate vendor.
+should mention that a TLS verification email will be sent to them. It also helps if you include the domain name(s)
+to be secured and the name of the TLS certificate vendor.
 
 The infrastructure team are unable to validate requests sent to any @service.gov.uk address.

--- a/service-manual/domain-names/index.md
+++ b/service-manual/domain-names/index.md
@@ -1,6 +1,6 @@
 ---
 layout: category-index
-title: Domain Names, SSL, Email
+title: Domain Names, TLS, Email
 subtitle: Where things live on the web
 category: operations
 type: category-index

--- a/service-manual/making-software/deployment.md
+++ b/service-manual/making-software/deployment.md
@@ -259,7 +259,7 @@ provide some means of achieving this. For example, Puppet 3 provides
 ### Secrets ###
 
 Extra care must be taken when managing secrets such as database
-passwords or SSL keys. You want to ensure:
+passwords or TLS keys. You want to ensure:
 
  * at a coarse-grained level, secrets cannot be accessed outside of
    the environment which uses them
@@ -267,7 +267,7 @@ passwords or SSL keys. You want to ensure:
    in an environment which need to know them.
 
 For example, in a three-tier app with database, application and web
-servers, the database server does not need to know the  SSL (secure sockets layer) private
+servers, the database server does not need to know the TLS (Transport Layer Security) private
 keys for the site, nor does the web server need to know the database credentials.
 
 If you are using hiera, then [hiera-gpg][] provides a solution to this

--- a/service-manual/operations/operating-servicegovuk-subdomains.md
+++ b/service-manual/operations/operating-servicegovuk-subdomains.md
@@ -73,7 +73,7 @@ Regardless of the domain name used, web-based services on testing and developmen
 
 Many services will collect personal information from users. It’s very important that this information can’t be intercepted by malicious third parties as it travels over the internet.
 
-Therefore, all services accessed through `service.gov.uk` domains (including APIs) MUST only be accessible through secure connections. For web-based services this means HTTPS only (often referred to by the acronyms TLS or SSL, which both refer to the protocol underpinning these secure connections). Services must not accept HTTP connections under any circumstances.
+Therefore, all services accessed through `service.gov.uk` domains (including APIs) MUST only be accessible through secure connections. For web-based services this means HTTPS only (often referred to by the acronym TLS, which refers to the protocol underpinning these secure connections). Services must not accept HTTP connections under any circumstances.
 
 Once a service manager has verified that their HTTPS setup is working fine they SHOULD enable [HSTS](https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security) on the production domains (`www.`, `admin.` and `assets.`), by setting an HTTP response header such as
 
@@ -122,11 +122,11 @@ Detailed configuration advice for origin servers is outside of the scope of this
 - the DDOS protection provider’s servers
 - the locations where the service itself is being developed and/or managed
 
-At present we advise against allowing DDOS protection suppliers to terminate SSL connections for transactional services carrying personal information, but this behaviour isn't prohibited at present. Although SSL termination on the third party network would allow the supplier(s) to carry out additional analysis and potentially extra mitigations against certain types of attack, it would also give the supplier access to all the personal information being submitted to your service. 
+At present we advise against allowing DDOS protection suppliers to terminate TLS connections for transactional services carrying personal information, but this behaviour isn't prohibited at present. Although TLS termination on the third party network would allow the supplier(s) to carry out additional analysis and potentially extra mitigations against certain types of attack, it would also give the supplier access to all the personal information being submitted to your service. 
 
-There are obvious downsides to allowing this level of access, especially if the supplier’s network and processes have not been accredited to the same level as the rest of the service. It’s a risk-based decision, but if in doubt we suggest a presumption against SSL termination on third party networks.
+There are obvious downsides to allowing this level of access, especially if the supplier’s network and processes have not been accredited to the same level as the rest of the service. It’s a risk-based decision, but if in doubt we suggest a presumption against TLS termination on third party networks.
 
-Many suppliers offer IP forwarding DDOS protection, which does not have the same security issues as SSL termination, and is recommended in preference to SSL termination.  If your service requires transaction monitoring (which is not at all the same thing as DDOS protection) you should contact your CESG account manager for advice.
+Many suppliers offer IP forwarding DDOS protection, which does not have the same security issues as TLS termination, and is recommended in preference to TLS termination.  If your service requires transaction monitoring (which is not at all the same thing as DDOS protection) you should contact your CESG account manager for advice.
 
 ## Emails sent to service users
 
@@ -138,10 +138,10 @@ You SHOULD enable [SPF](https://en.wikipedia.org/wiki/Sender_Policy_Framework) o
 
 If your service should need to wind down for any reason, you MUST ensure continued useful service and information for users by:
 
-* continuing to use SSL
+* continuing to use TLS
 * serving a redirect from your service to the GOV.UK start page
 
-For services that have been live for less than 6 months, you MUST continue to do the above for the remainder of a year total. For services that have been live longer than that you MUST continue to do the above for a further 12 months or until the expiry of the current SSL certificate, whichever comes first.
+For services that have been live for less than 6 months, you MUST continue to do the above for the remainder of a year total. For services that have been live longer than that you MUST continue to do the above for a further 12 months or until the expiry of the current TLS certificate, whichever comes first.
 
 The GOV.UK start page will be amended to explain that the service is no longer running, and cease to provide a start button pointing at the defunct service.
 


### PR DESCRIPTION
Since POODLE, we should not encourage any usage of SSL. Instead, we
should explicitly encourage TLS.

Googling for TLS vendors returns what I would expect; namely, SSL
vendors.