### PR TITLE
Add hackpad link to NINO pattern

### DIFF
--- a/service-manual/user-centred-design/resources/patterns/index.md
+++ b/service-manual/user-centred-design/resources/patterns/index.md
@@ -31,7 +31,7 @@ for guidance on styling the basic form elements.
   <li><a href="/service-manual/user-centred-design/resources/patterns/names">Names</a></li>
   <li><a href="/service-manual/user-centred-design/resources/patterns/dates">Dates</a></li>
   <li><a href="/service-manual/user-centred-design/resources/patterns/addresses">Addresses</a></li>
-  <li><a href="/service-manual/user-centred-design/resources/patterns/national-insurance-number">National insurance numbers</a></li>
+  <li><a href="/service-manual/user-centred-design/resources/patterns/national-insurance-number">National Insurance numbers</a></li>
 </ul>
 
 

--- a/service-manual/user-centred-design/resources/patterns/national-insurance-number.md
+++ b/service-manual/user-centred-design/resources/patterns/national-insurance-number.md
@@ -29,6 +29,4 @@ Do not use "AB 12 34 56 C" as an example (it belongs to a real person).
 Instead, use: "QQ 12 34 56 C"
 
 
-## Further reading
-
-* [https://en.wikipedia.org/wiki/National_Insurance_number](https://en.wikipedia.org/wiki/National_Insurance_number)
+[Discuss this page on hackpad](https://designpatterns.hackpad.com/National-Insurance-numbers-ss56rQhpcBT)


### PR DESCRIPTION
On the NINO pattern page: Changed link to wikipedia to a link to our
hackpad discussion of this pattern.
On the patterns index page: changed 'insurance' to 'Insurance' to align
with advice in pattern

(This is part of a programme to rationalise and improve our forms guidance)