### PR TITLE
Change order of design patterns to show typical use

### DIFF
--- a/service-manual/user-centred-design/resources/patterns/index.md
+++ b/service-manual/user-centred-design/resources/patterns/index.md
@@ -34,6 +34,7 @@ The patterns below describe our approach to services, transactions and forms.
 
 ## Process patterns
 These patterns are about things that you need to do, for example: ask for a start page.
+
 * [Form structure](/service-manual/user-centred-design/resources/patterns/form-structure)
 * [Alpha and beta banners](/service-manual/user-centred-design/resources/patterns/alpha-beta)
 * [Start pages](/service-manual/user-centred-design/resources/patterns/start-pages)

--- a/service-manual/user-centred-design/resources/patterns/index.md
+++ b/service-manual/user-centred-design/resources/patterns/index.md
@@ -22,23 +22,23 @@ Start with [the GOV.UK elements](/service-manual/user-centred-design/resources/e
 The patterns below describe our approach to services, transactions and forms.
 
 ## Detail patterns
-* [Names](/service-manual/user-centred-design/resources/patterns/names)
-* [Dates](/service-manual/user-centred-design/resources/patterns/dates)
-* [Addresses](/service-manual/user-centred-design/resources/patterns/addresses)
-* [National Insurance numbers](/service-manual/user-centred-design/resources/patterns/national-insurance-number)
-* [Summary pages](/service-manual/user-centred-design/resources/patterns/summary-pages)
-* [Confirmation pages](/service-manual/user-centred-design/resources/patterns/confirmation-pages)
-* [Help text](/service-manual/user-centred-design/resources/patterns/help-text)
-* [Progress indicators](/service-manual/user-centred-design/resources/patterns/progress-indicators)
+* [Names](/service-manual/user-centred-design/resources/patterns/names.html)
+* [Dates](/service-manual/user-centred-design/resources/patterns/dates.html)
+* [Addresses](/service-manual/user-centred-design/resources/patterns/addresses.html)
+* [National Insurance numbers](/service-manual/user-centred-design/resources/patterns/national-insurance-number.html)
+* [Summary pages](/service-manual/user-centred-design/resources/patterns/summary-pages.html)
+* [Confirmation pages](/service-manual/user-centred-design/resources/patterns/confirmation-pages.html)
+* [Help text](/service-manual/user-centred-design/resources/patterns/help-text.html)
+* [Progress indicators](/service-manual/user-centred-design/resources/patterns/progress-indicators.html)
 
 
 ## Process patterns
 These patterns are about things that you need to do, for example: ask for a start page.
 
-* [Form structure](/service-manual/user-centred-design/resources/patterns/form-structure)
-* [Alpha and beta banners](/service-manual/user-centred-design/resources/patterns/alpha-beta)
-* [Start pages](/service-manual/user-centred-design/resources/patterns/start-pages)
-* [Done pages](/service-manual/user-centred-design/resources/patterns/done-pages)
+* [Form structure](/service-manual/user-centred-design/resources/patterns/form-structure.html)
+* [Alpha and beta banners](/service-manual/user-centred-design/resources/patterns/alpha-beta.html)
+* [Start pages](/service-manual/user-centred-design/resources/patterns/start-pages.html)
+* [Done pages](/service-manual/user-centred-design/resources/patterns/done-pages.html)
 
 ---
 

--- a/service-manual/user-centred-design/resources/patterns/index.md
+++ b/service-manual/user-centred-design/resources/patterns/index.md
@@ -19,7 +19,7 @@ The Design Patterns section is split into two areas, broadly organised according
 
 <ul>
  <li>If you're doing design then you'll probably find the Detail and Process patterns (below) most useful; they're mostly about which patterns to use and why we're recommending them.</li>
- <li>If you're doing development then you'll probably find the [the GOV.UK elements](/service-manual/user-centred-design/resources/elements)  most useful; they're mostly about how to make your service look consistent with GOV.UK and include links to code snippets. </li>
+ <li>If you're doing development then you'll probably find [the GOV.UK elements](/service-manual/user-centred-design/resources/elements)  most useful; they're mostly about how to make your service look consistent with GOV.UK and include links to code snippets. </li>
 </ul>
 
 Whatever you're doing, you'll need to use these patterns as part of a user-centred design approach.

--- a/service-manual/user-centred-design/resources/patterns/index.md
+++ b/service-manual/user-centred-design/resources/patterns/index.md
@@ -15,40 +15,30 @@ breadcrumbs:
 ---
 
 {:.intro}
-The Design Patterns section is split into two areas, broadly organised according to the main task they are supposed to help with. 
+Use these design patterns to maintain a consistent design across our services.
 
-<ul>
- <li>If you're doing design then you'll probably find the Detail and Process patterns (below) most useful; they're mostly about which patterns to use and why we're recommending them.</li>
- <li>If you're doing development then you'll probably find [the GOV.UK elements](/service-manual/user-centred-design/resources/elements)  most useful; they're mostly about how to make your service look consistent with GOV.UK and include links to code snippets. </li>
-</ul>
+Start with [the GOV.UK elements](/service-manual/user-centred-design/resources/elements) page, to find out how to make your service look consistent with GOV.UK. It also includes links to code snippets.
 
-Whatever you're doing, you'll need to use these patterns as part of a user-centred design approach.
+The patterns below describe our approach to services, transactions and forms.
 
-### Detail patterns
-These patterns bring together our approach to selected details of services, transactions, and forms.
-
-<ul>
-  <li><a href="/service-manual/user-centred-design/resources/patterns/names">Names</a></li>
-  <li><a href="/service-manual/user-centred-design/resources/patterns/dates">Dates</a></li>
-  <li><a href="/service-manual/user-centred-design/resources/patterns/addresses">Addresses</a></li>
-  <li><a href="/service-manual/user-centred-design/resources/patterns/national-insurance-number">National Insurance numbers</a></li>
- <li><a href="/service-manual/user-centred-design/resources/patterns/summary-pages">Summary pages</a></li>
-  <li><a href="/service-manual/user-centred-design/resources/patterns/confirmation-pages">Confirmation pages</a></li>
- <li><a href="/service-manual/user-centred-design/resources/patterns/help-text">Help text</a></li>
-<li><a href="/service-manual/user-centred-design/resources/patterns/progress-indicators">Progress indicators</a></li>
-
-</ul>
+## Detail patterns
+* [Form structure](/service-manual/user-centred-design/resources/patterns/form-structure)
+* [Names](/service-manual/user-centred-design/resources/patterns/names)
+* [Dates](/service-manual/user-centred-design/resources/patterns/dates)
+* [Addresses](/service-manual/user-centred-design/resources/patterns/addresses)
+* [National Insurance numbers](/service-manual/user-centred-design/resources/patterns/national-insurance-number)
+* [Summary pages](/service-manual/user-centred-design/resources/patterns/summary-pages)
+* [Confirmation pages](/service-manual/user-centred-design/resources/patterns/confirmation-pages)
+* [Help text](/service-manual/user-centred-design/resources/patterns/help-text)
+* [Progress indicators](/service-manual/user-centred-design/resources/patterns/progress-indicators)
 
 
-### Process patterns
-These patterns are mostly about things that you need to do (such as: ask for a start page) or ways to think about wider issues such as the relationship between parts of a transaction and user needs (such as: form structure). 
-<ul>
-  <li><a href="/service-manual/user-centred-design/resources/patterns/form-structure">Form structure</a></li>
-  <li><a href="/service-manual/user-centred-design/resources/patterns/start-pages">Start pages</a></li>
-   <li><a href="/service-manual/user-centred-design/resources/patterns/done-pages">Done pages</a></li>
-  <li><a href="/service-manual/user-centred-design/resources/patterns/alpha-beta">Alpha and beta banners</a></li>
+## Process patterns
+These patterns are about things that you need to do, for example: ask for a start page.
 
-</ul>
+* [Alpha and beta banners](/service-manual/user-centred-design/resources/patterns/alpha-beta)
+* [Start pages](/service-manual/user-centred-design/resources/patterns/start-pages)
+* [Done pages](/service-manual/user-centred-design/resources/patterns/done-pages)
 
 ---
 

--- a/service-manual/user-centred-design/resources/patterns/index.md
+++ b/service-manual/user-centred-design/resources/patterns/index.md
@@ -15,44 +15,44 @@ breadcrumbs:
 ---
 
 {:.intro}
-These patterns take the GOV.UK elements and combine them to meet common user needs.
-Use them to maintain a consistent design across our services.
-
-
-### Forms
-
-See [the GOV.UK elements page](/service-manual/user-centred-design/resources/elements)
-for guidance on styling the basic form elements.
+The Design Patterns section is split into two areas, broadly organised according to the main task they are supposed to help with. 
 
 <ul>
-  <li><a href="/service-manual/user-centred-design/resources/patterns/form-structure">Form structure</a></li>
-  <li><a href="/service-manual/user-centred-design/resources/patterns/progress-indicators">Progress indicators</a></li>
-  <li><a href="/service-manual/user-centred-design/resources/patterns/help-text">Help text</a></li>
+ <li>If you're doing design then you'll probably find the Detail and Process patterns (below) most useful; they're mostly about which patterns to use and why we're recommending them.</li>
+ <li>If you're doing development then you'll probably find the [the GOV.UK elements](/service-manual/user-centred-design/resources/elements)  most useful; they're mostly about how to make your service look consistent with GOV.UK and include links to code snippets. </li>
+</ul>
+
+Whatever you're doing, you'll need to use these patterns as part of a user-centred design approach.
+
+### Detail patterns
+These patterns bring together our approach to selected details of services, transactions, and forms.
+
+<ul>
   <li><a href="/service-manual/user-centred-design/resources/patterns/names">Names</a></li>
   <li><a href="/service-manual/user-centred-design/resources/patterns/dates">Dates</a></li>
   <li><a href="/service-manual/user-centred-design/resources/patterns/addresses">Addresses</a></li>
   <li><a href="/service-manual/user-centred-design/resources/patterns/national-insurance-number">National Insurance numbers</a></li>
+ <li><a href="/service-manual/user-centred-design/resources/patterns/summary-pages">Summary pages</a></li>
+  <li><a href="/service-manual/user-centred-design/resources/patterns/confirmation-pages">Confirmation pages</a></li>
+ <li><a href="/service-manual/user-centred-design/resources/patterns/help-text">Help text</a></li>
+<li><a href="/service-manual/user-centred-design/resources/patterns/progress-indicators">Progress indicators</a></li>
+
 </ul>
 
 
-### Transaction pages
-
+### Process patterns
+These patterns are mostly about things that you need to do (such as: ask for a start page) or ways to think about wider issues such as the relationship between parts of a transaction and user needs (such as: form structure). 
 <ul>
+  <li><a href="/service-manual/user-centred-design/resources/patterns/form-structure">Form structure</a></li>
   <li><a href="/service-manual/user-centred-design/resources/patterns/start-pages">Start pages</a></li>
-  <li><a href="/service-manual/user-centred-design/resources/patterns/summary-pages">Summary pages</a></li>
-  <li><a href="/service-manual/user-centred-design/resources/patterns/confirmation-pages">Confirmation pages</a></li>
-  <li><a href="/service-manual/user-centred-design/resources/patterns/done-pages">Done pages</a></li>
+   <li><a href="/service-manual/user-centred-design/resources/patterns/done-pages">Done pages</a></li>
   <li><a href="/service-manual/user-centred-design/resources/patterns/alpha-beta">Alpha and beta banners</a></li>
+
 </ul>
 
 ---
 
 ## Get involved
 
-The patterns here are based on best practice and user research.
-However, if you find a better approach to something or want to suggest a new pattern then let us know on the [design patterns wiki](https://designpatterns.hackpad.com/GOV.UK-design-patterns-0eUk1OdHvql).
-
-
-
-<br>
+These patterns are always being tested and improved. If you find a better approach to something or want to suggest a new pattern then let us know on the [design patterns wiki](https://designpatterns.hackpad.com/GOV.UK-design-patterns-0eUk1OdHvql).
 <br>

--- a/service-manual/user-centred-design/resources/patterns/index.md
+++ b/service-manual/user-centred-design/resources/patterns/index.md
@@ -22,7 +22,6 @@ Start with [the GOV.UK elements](/service-manual/user-centred-design/resources/e
 The patterns below describe our approach to services, transactions and forms.
 
 ## Detail patterns
-* [Form structure](/service-manual/user-centred-design/resources/patterns/form-structure)
 * [Names](/service-manual/user-centred-design/resources/patterns/names)
 * [Dates](/service-manual/user-centred-design/resources/patterns/dates)
 * [Addresses](/service-manual/user-centred-design/resources/patterns/addresses)
@@ -35,7 +34,7 @@ The patterns below describe our approach to services, transactions and forms.
 
 ## Process patterns
 These patterns are about things that you need to do, for example: ask for a start page.
-
+* [Form structure](/service-manual/user-centred-design/resources/patterns/form-structure)
 * [Alpha and beta banners](/service-manual/user-centred-design/resources/patterns/alpha-beta)
 * [Start pages](/service-manual/user-centred-design/resources/patterns/start-pages)
 * [Done pages](/service-manual/user-centred-design/resources/patterns/done-pages)


### PR DESCRIPTION
Some design patterns are rather precise 'do it like this'; others are
more about how to think about a topic. This rearrangement groups them
according to the way they might be used.
![design-patterns-screenshot](https://cloud.githubusercontent.com/assets/8270092/6006406/1fb31220-ab0a-11e4-9277-5556ca9c5906.gif)
