### PR TITLE
Begin migration from Classic to Universal analytics

### DIFF
--- a/_includes/layouts/_body.html
+++ b/_includes/layouts/_body.html
@@ -1,11 +1,11 @@
-<script src="/service-manual/assets/javascript/jquery-1.7.2.js" type="text/javascript"></script>
-<script src="/service-manual/assets/javascript/jquery-ui-1.10.2.custom.js?cache={{ site.time | date: "%s" }}" type="text/javascript"></script>
-<script src="/service-manual/assets/toolkit/javascripts/vendor/jquery/jquery.player.min.js?cache={{ site.time | date: "%s" }}" type="text/javascript"></script>
-<script src="/service-manual/assets/javascript/toggler.js?cache={{ site.time | date: "%s" }}" type="text/javascript"></script>
-<script src="/service-manual/assets/javascript/media-player-loader.js?cache={{ site.time | date: "%s" }}" type="text/javascript"></script>
-<script src="/service-manual/assets/javascript/forms.js?cache={{ site.time | date: "%s" }}" type="text/javascript"></script>
+<script src="/service-manual/assets/javascript/jquery-1.7.2.js"></script>
+<script src="/service-manual/assets/javascript/jquery-ui-1.10.2.custom.js?cache={{ site.time | date: "%s" }}"></script>
+<script src="/service-manual/assets/toolkit/javascripts/vendor/jquery/jquery.player.min.js?cache={{ site.time | date: "%s" }}"></script>
+<script src="/service-manual/assets/javascript/toggler.js?cache={{ site.time | date: "%s" }}"></script>
+<script src="/service-manual/assets/javascript/media-player-loader.js?cache={{ site.time | date: "%s" }}"></script>
+<script src="/service-manual/assets/javascript/forms.js?cache={{ site.time | date: "%s" }}"></script>
 
-<script id="ga-params" type="text/javascript">
+<script id="ga-params">
   var GOVUK = GOVUK || {};
   GOVUK.Analytics = GOVUK.Analytics || {};
   var _gaq = _gaq || [];
@@ -21,7 +21,7 @@
     _gaq.push(['_setCustomVar', 11, 'Pixel Ratio', String(window.devicePixelRatio), 2 ]);
   }
 </script>
-<script type="text/javascript">
+<script>
   _gaq.push(['_gat._anonymizeIp']);
   _gaq.push(['_trackPageview']);
   (function() {

--- a/_includes/layouts/_body.html
+++ b/_includes/layouts/_body.html
@@ -1,32 +1,10 @@
 <script src="/service-manual/assets/javascript/jquery-1.7.2.js"></script>
 <script src="/service-manual/assets/javascript/jquery-ui-1.10.2.custom.js?cache={{ site.time | date: "%s" }}"></script>
 <script src="/service-manual/assets/toolkit/javascripts/vendor/jquery/jquery.player.min.js?cache={{ site.time | date: "%s" }}"></script>
+<script src="/service-manual/assets/toolkit/javascripts/govuk/analytics/google-analytics-classic-tracker.js?cache={{ site.time | date: "%s" }}"></script>
+<script src="/service-manual/assets/toolkit/javascripts/govuk/analytics/google-analytics-universal-tracker.js?cache={{ site.time | date: "%s" }}"></script>
+<script src="/service-manual/assets/toolkit/javascripts/govuk/analytics/tracker.js?cache={{ site.time | date: "%s" }}"></script>
+<script src="/service-manual/assets/javascript/analytics-init.js?cache={{ site.time | date: "%s" }}"></script>
 <script src="/service-manual/assets/javascript/toggler.js?cache={{ site.time | date: "%s" }}"></script>
 <script src="/service-manual/assets/javascript/media-player-loader.js?cache={{ site.time | date: "%s" }}"></script>
 <script src="/service-manual/assets/javascript/forms.js?cache={{ site.time | date: "%s" }}"></script>
-
-<script id="ga-params">
-  var GOVUK = GOVUK || {};
-  GOVUK.Analytics = GOVUK.Analytics || {};
-  var _gaq = _gaq || [];
-  _gaq.push(['_setAccount', 'UA-26179049-1']);
-  if(document.domain=='www.gov.uk') {
-    _gaq.push(['_setDomainName', '.www.gov.uk']);
-  } else {
-    _gaq.push(['_setDomainName', document.domain]);
-  }
-  _gaq.push(['_setAllowLinker', true]);
-    // track pixel density ratio
-  if (window.devicePixelRatio) {
-    _gaq.push(['_setCustomVar', 11, 'Pixel Ratio', String(window.devicePixelRatio), 2 ]);
-  }
-</script>
-<script>
-  _gaq.push(['_gat._anonymizeIp']);
-  _gaq.push(['_trackPageview']);
-  (function() {
-    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-  })();
-</script>

--- a/service-manual/assets/javascript/analytics-init.js
+++ b/service-manual/assets/javascript/analytics-init.js
@@ -1,0 +1,18 @@
+(function() {
+  "use strict";
+
+  GOVUK.Tracker.load();
+  var cookieDomain = (document.domain === 'www.gov.uk') ? '.www.gov.uk' : document.domain;
+
+  GOVUK.analytics = new GOVUK.Tracker({
+    universalId: 'UA-26179049-7',
+    classicId: 'UA-26179049-1',
+    cookieDomain: cookieDomain
+  });
+
+  if (window.devicePixelRatio) {
+    GOVUK.analytics.setDimension(11, window.devicePixelRatio, 'Pixel Ratio', 2);
+  }
+
+  GOVUK.analytics.trackPageview();
+})();


### PR DESCRIPTION
All apps should use Universal alongside Classic so we can test the implementation and be ready to complete the upgrade to Universal once testing is complete.

* Update frontend toolkit to 3.3.0 to pull in the latest analytics javascript
* Add an `analytics-init` file to configure and start the tracker (reference: https://github.com/alphagov/govuk_frontend_toolkit/blob/master/docs/analytics.md#create-an-analytics-tracker)
* Remove inline script tags and `text/javascript` attributes

Because js files aren't concatenated and minified in the service manual I've avoided pulling in the print and error tracking for now.

Story: https://www.pivotaltracker.com/story/show/89525510