### PR TITLE
April 2014 was a long time ago...

### DIFF
--- a/service-manual/index.html
+++ b/service-manual/index.html
@@ -6,7 +6,7 @@ category: home
 <div class="dbd-promo">
   <h1 class="logo"><a href="/service-manual/digital-by-default"><img src="/service-manual/assets/images/DbD-kitemark.png" alt="Read the Digital by Default Service Standard" /></a></h1>
   <p>
-    From April 2014, digital services from the government must meet the new Digital by Default Service Standard.
+    All new digital services from the government must meet the Digital by Default Service Standard.
     <br>
 
     <strong><a href="/service-manual/digital-by-default">Read the standard &raquo;</a></strong>


### PR DESCRIPTION
The front page of the Service Manual notes that the DbD standard only applies
for services built from April 2014 onward. Whilst this is technically true, I
think the homepage looks dated with this tidbit included.

Reworded.