### PR TITLE
Index like other manuals

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'rake', '10.3.2'
 
 gem 'plek', '1.5.0'
 gem 'gds-api-adapters', '14.1.0'
-gem 'rummageable', '0.6.2'
+gem 'rummageable', '1.2.0'
 
 gem 'colorize', '0.7.3'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,7 @@ GEM
     mercenary (0.3.4)
     mime-types (1.25.1)
     mini_portile (0.6.0)
+    multi_json (1.11.0)
     nokogiri (1.6.3.1)
       mini_portile (= 0.6.0)
     null_logger (0.0.1)
@@ -94,9 +95,9 @@ GEM
     rest-client (1.6.8)
       mime-types (~> 1.16)
       rdoc (>= 2.4.2)
-    rummageable (0.6.2)
-      json
-      plek (>= 0.5.0)
+    rummageable (1.2.0)
+      multi_json
+      null_logger
       rest-client
     safe_yaml (1.0.3)
     sass (3.3.11)
@@ -132,7 +133,7 @@ DEPENDENCIES
   nokogiri (= 1.6.3.1)
   plek (= 1.5.0)
   rake (= 10.3.2)
-  rummageable (= 0.6.2)
+  rummageable (= 1.2.0)
   sinatra (= 1.4.5)
   thin (= 1.6.2)
   unicorn (= 4.8.3)

--- a/Rakefile
+++ b/Rakefile
@@ -81,6 +81,7 @@ end
 
 namespace :rummager do
   task :index do
+    require 'plek'
     require 'rummageable'
 
     search_index = File.expand_path('../.search-index.json', __FILE__)
@@ -90,6 +91,7 @@ namespace :rummager do
     parsed = JSON.parse(content)
     puts "Handling #{parsed.count} records from #{search_index}"
 
-    Rummageable.index(parsed, '/service-manual')
+    rummageable_index = Rummageable::Index.new(Plek.current.find('search'), '/service-manual')
+    rummageable_index.add_batch(parsed)
   end
 end

--- a/_plugins/jekyll_rummageable/indexer.rb
+++ b/_plugins/jekyll_rummageable/indexer.rb
@@ -6,6 +6,8 @@ module Jekyll
 
   class Indexer < Generator
 
+    MANUAL_TITLE = "Government Service Design Manual"
+
     def initialize(config = {})
       super(config)
 
@@ -34,12 +36,22 @@ module Jekyll
         page_paragraphs = extract_text(site, item)
 
         {
-          "title"             => item.data['title'] || item.name ,
+          "_type"             => "manual_section",
+          "organisations"     => ["government-digital-service"],
+          "manual"            => "service-manual",
+          "title"             => "#{MANUAL_TITLE}: #{item.data['title'] || item.name}",
           "indexable_content" => page_paragraphs.join(" ").gsub("\r"," ").gsub("\n"," "),
           "description"       => extract_summary(site, item),
           "link"              => item.url
         }
       end
+      index << {
+        "_type"             => "manual",
+        "organisations"     => ["government-digital-service"],
+        "title"             => MANUAL_TITLE,
+        "description"       => "All new digital services from the government must meet the Digital by Default Service Standard",
+        "link"              => "/service-manual",
+      }
       puts 'Indexing done, writing index to file'
       write_index_to_file(site, index)
       puts 'Index written to file'

--- a/app.rb
+++ b/app.rb
@@ -30,7 +30,9 @@ class ServiceManual < Sinatra::Base
         @results = []
       else
         res = search_client.search(@search_term)
-        @results = res['results']
+        @results = res['results'].map { |result|
+          result.merge({'title' => result['title'].gsub(/\AGovernment Service Design Manual: /, '')})
+        }
         @count = res['total']
         page_settings['title'] = "Search results for #{@search_term}"
       end


### PR DESCRIPTION
Index documents using the "manual" formats
This depends on alphagov/rummager#399; I'll
deploy both that and this change together.

So that we can move to using the `unified_search` endpoint, we want to
index documents from the service manual the same as if they were from
one of the standard manuals on GOV.UK (ie, using the recently introduced
`manual` and `manual-section` formats).

This requires several changes:

 - update version of rummageable, since the old one doesn't allow anything
   except for a very limited set of fields to be sent.

 - the documents from the manual need to be indexed with their type set
   to `manual_section`.

 - manuals are generally associated with an organisation, so associate
   this manual with the GDS organisation.

 - the titles in search of all existing `manual_section` documents are
   prefixed with the name of the manual.  This makes them make more
   sense when they come up in general site search, but is undesirable
   when the search is restricted to a single manual.  Therefore, we also
   strip this prefix off again when presenting the results in this app.

 - for search-within-a-manual to work fully, we need a `manual` document
   to describe the manual.  This is a good idea anyway, because
   we're currently using the "recommended-links" app to add a link to
   search, so that a search for "service-manual" on GOV.UK finds it.
   This document requires a "description" field, for which I've copied
   the existing description used for the link in the "recommended-links"
   app.

This PR shouldn't change the results shown to users at all.