### PR TITLE
Use the unified search endpoint

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -91,7 +91,7 @@ namespace :rummager do
     parsed = JSON.parse(content)
     puts "Handling #{parsed.count} records from #{search_index}"
 
-    rummageable_index = Rummageable::Index.new(Plek.current.find('search'), '/service-manual')
+    rummageable_index = Rummageable::Index.new(Plek.current.find('rummager'), '/service-manual')
     rummageable_index.add_batch(parsed)
   end
 end

--- a/app.rb
+++ b/app.rb
@@ -29,7 +29,7 @@ class ServiceManual < Sinatra::Base
       if @search_term.nil? or @search_term.strip.empty?
         @results = []
       else
-        res = search_client.search(@search_term)
+        res = search_client.unified_search(q: @search_term, filter_manual: "service-manual")
         @results = res['results'].map { |result|
           result.merge({'title' => result['title'].gsub(/\AGovernment Service Design Manual: /, '')})
         }
@@ -93,7 +93,7 @@ class ServiceManual < Sinatra::Base
   end
 
   def search_client
-    @search_client ||= GdsApi::Rummager.new(Plek.current.find('search') + '/service-manual')
+    @search_client ||= GdsApi::Rummager.new(Plek.current.find('rummager'))
   end
 
   # Start the server if this Ruby file is executed directly


### PR DESCRIPTION
Instead of using the old /search endpoint on rummager, use the
/unified_search endpoint, applying a filter on the manual field to
return only service-manual documents.

In my testing, this returns the same results as using the /search
endpoint, and they look the same.  The ordering may vary slightly,
because the unified_search endpoint applies some popularity adjustments
to its weighting, but I expect these to be an improvement, if anything.

Also, use Plek.find("rummager") instead of Plek.find("search") now that
we've defined a rummager name; we should start moving to that, instead
of search when we're making changes in that area.

Depends on https://github.com/alphagov/rummager/pull/402.