### PR TITLE
Change the text of the "Cymraeg" link in the footer

### DIFF
--- a/_search/includes/layouts/_footer_support_links.liquid
+++ b/_search/includes/layouts/_footer_support_links.liquid
@@ -2,6 +2,6 @@
   <li><a href="/help">Help</a></li>
   <li><a href="/help/cookies">Cookies</a></li>
   <li><a href="/contact">Contact</a></li>
-  <li><a href="/cymraeg">Cymraeg</a></li>
+  <li><a href="/cymraeg">Rhestr o Wasanaethau Cymraeg</a></li>
   <li>Built by the <a href="https://gds.blog.gov.uk/">Government Digital Service</a></li>
 </ul>

--- a/_search/includes/layouts/_footer_support_links.liquid
+++ b/_search/includes/layouts/_footer_support_links.liquid
@@ -3,5 +3,5 @@
   <li><a href="/help/cookies">Cookies</a></li>
   <li><a href="/contact">Contact</a></li>
   <li><a href="/cymraeg">Rhestr o Wasanaethau Cymraeg</a></li>
-  <li>Built by the <a href="https://gds.blog.gov.uk/">Government Digital Service</a></li>
+  <li>Built by the <a href="https://www.gov.uk/government/organisations/government-digital-service">Government Digital Service</a></li>
 </ul>


### PR DESCRIPTION
- Research shows users think clicking the "Cymraeg" link will take
  them to a translated version of the page they are on, rather than a
  specific list of services GOV.UK has translated into Welsh. The
  phrase "Rhestr o Wasanaethau Cymraeg" better describes the nature of
  the page users are taken to.
- Originally changed this in https://github.com/alphagov/static/pull/578
  and am now updating everything that contains our footer without
  pulling in `static`.

("Rhestr o Wasanaethau Cymraeg" means "List of Welsh services", for those curious.)