### PR TITLE
New 18 point Digital Service Standard

### DIFF
--- a/service-manual/assets/stylesheets/views/_standard.scss
+++ b/service-manual/assets/stylesheets/views/_standard.scss
@@ -96,6 +96,20 @@
 
   }
 
+  // Archived content notice
+  .status-block {
+    @include media(desktop) {
+      width: 67%;
+      margin: 30px auto;
+    }
+    margin-left: 0;
+    margin-right: 0;
+    border: 5px solid $govuk-blue;
+    padding: 30px 15px;
+
+    @include core-36;
+  }
+
   // The list of criteria
   .standard {
     //display: inline-block;
@@ -200,6 +214,18 @@
       }
     }
 
+  }
+
+  // The updated list of criteria
+  .updated-standard {
+    li {
+      .point {
+        // Increase width of point wrapper for tablet and up
+        @include media(tablet) {
+          width: 67%;
+        }
+      }
+    }
   }
 
   .link-list {

--- a/service-manual/digital-by-default-26-points/index.md
+++ b/service-manual/digital-by-default-26-points/index.md
@@ -14,6 +14,10 @@ breadcrumbs:
     url: /service-manual
 ---
 
+<div class="status-block">
+  The information on this page has been replaced by the <a href="/service-manual/digital-by-default/"> 18 point Digital Service Standard</a>.
+</div>
+
 <div class="intro">
 
   <img src="/service-manual/assets/images/DbD-kitemark.png" />

--- a/service-manual/digital-by-default/assessments-at-gds.md
+++ b/service-manual/digital-by-default/assessments-at-gds.md
@@ -32,7 +32,7 @@ You can start the assessment process by asking GDS Approvals (gdsapprovals@digit
 
 ## Attending the assessment
 
-You should give a brief overview of the service including a live demonstration. Video screens and cables will be provided. The assessment panel will ask you to answer questions to show how the service meets the standard. You will normally bring other team members along to represent different aspects of the service and help answer questions. Often they will be a technical architect, a designer, a user researcher or a delivery manager, but that’s up to you. The assessment can last up to 3 hours depending on the service’s complexity, and will assess against all 26 points in the standard.
+You should give a brief overview of the service including a live demonstration. Video screens and cables will be provided. The assessment panel will ask you to answer questions to show how the service meets the standard. You will normally bring other team members along to represent different aspects of the service and help answer questions. Often they will be a technical architect, a designer, a user researcher or a delivery manager, but that’s up to you. The assessment can last up to 3 hours depending on the service’s complexity, and will assess against all 18 points in the standard.
 
 ## Outcomes from an assessment
 

--- a/service-manual/digital-by-default/index.md
+++ b/service-manual/digital-by-default/index.md
@@ -1,0 +1,134 @@
+---
+layout: standard
+title: Digital by Default Service Standard
+subtitle: Services so good that people prefer to use them
+audience:
+  primary: service-manager
+  secondary:
+theme: getting-started
+category: dbd
+status: draft
+breadcrumbs:
+  -
+    title: Home
+    url: /service-manual
+---
+
+<div class="intro">
+
+  <img src="/service-manual/assets/images/DbD-kitemark.png" />
+
+  <p>
+    The Digital Service Standard has changed from <a href="/service-manual/digital-by-default-26-points/">26 points</a> to a more concise 18. From 1 June 2015 all transactional services will be assessed on the new 18 points.
+  </p>
+
+  <p>
+    The Service Standard ensures digital teams build high quality government services.
+  </p>
+
+  <p>
+    A transactional service must meet each criteria to pass the Government Digital Service assessment. If a service doesn’t pass it won’t appear on GOV.UK.
+  </p>
+
+  <p>
+    Assisted digital support is an integral part of any service, helping users who can't complete the service on their own.
+  </p>
+
+</div>
+
+<h2>The criteria</h2>
+
+<ol class="standard updated-standard">
+  <li id="criterion-1">
+    <div class="point">
+      Understand user needs. Research to develop a deep knowledge of who the service users are and what that means for the design of the service.
+    </div>
+  </li>
+  <li id="criterion-2">
+    <div class="point">
+      Put a plan in place for ongoing user research and usability testing to continuously seek feedback from users to improve the service.
+    </div>
+  </li>
+  <li id="criterion-3">
+    <div class="point">
+      Put in place a sustainable multidisciplinary team that can design, build and operate the service, led by a suitably skilled and senior service manager with decision-making responsibility.
+    </div>
+  </li>
+  <li id="criterion-4">
+    <div class="point">
+      Build the service using the agile, iterative and user-centred methods set out in the manual.
+    </div>
+  </li>
+  <li id="criterion-5">
+    <div class="point">
+      Build a service that can be iterated and improved on a frequent basis and make sure that you have the capacity, resources and technical flexibility to do so.
+    </div>
+  </li>
+  <li id="criterion-6">
+    <div class="point">
+      Evaluate what tools and systems will be used to build, host, operate and measure the service, and how to procure them.
+    </div>
+  </li>
+  <li id="criterion-7">
+    <div class="point">
+      Evaluate what user data and information the digital service will be providing or storing, and address the security level, legal responsibilities, privacy issues and risks associated with the service (consulting with experts where appropriate).
+    </div>
+  </li>
+  <li id="criterion-8">
+    <div class="point">
+      Make all new source code open and reusable, and publish it under appropriate licences (or provide a convincing explanation as to why this cannot be done for specific subsets of the source code).
+    </div>
+  </li>
+  <li id="criterion-9">
+    <div class="point">
+      Use open standards and common government platforms where available.
+    </div>
+  </li>
+  <li id="criterion-10">
+    <div class="point">
+      Be able to test the end-to-end service in an environment identical to that of the live version, including on all common browsers and devices, and using dummy accounts and a representative sample of users.
+    </div>
+  </li>
+  <li id="criterion-11">
+    <div class="point">
+      Make a plan for the event of the digital service being taken temporarily offline.
+    </div>
+  </li>
+  <li id="criterion-12">
+    <div class="point">
+      Create a service that is simple and intuitive enough that users succeed first time.
+    </div>
+  </li>
+  <li id="criterion-13">
+    <div class="point">
+      Build a service consistent with the user experience of the rest of GOV.UK including using the design patterns and style guide.
+    </div>
+  </li>
+  <li id="criterion-14">
+    <div class="point">
+      Encourage all users to use the digital service (with assisted digital support if required), alongside an appropriate plan to phase out non-digital channels/services.
+    </div>
+  </li>
+  <li id="criterion-15">
+    <div class="point">
+      Use tools for analysis that collect performance data. Use this data to analyse the success of the service and to translate this into features and tasks for the next phase of development.
+    </div>
+  </li>
+  <li id="criterion-16">
+    <div class="point">
+      Identify performance indicators for the service, including the 4 mandatory key performance indicators (KPIs) defined in the manual. Establish a benchmark for each metric and make a plan to enable improvements.
+    </div>
+  </li>
+  <li id="criterion-17">
+    <div class="point">
+      Report performance data on the Performance Platform.
+    </div>
+  </li>
+  <li id="criterion-18">
+    <div class="point">
+      Test the service from beginning to end with the minister responsible for it.
+    </div>
+  </li>
+</ol>
+
+<p class="print-footer"><span>Find out more at www.gov.uk/service-manual/digital-by-default</span></p>


### PR DESCRIPTION
The Digital by Default Service Standard has been revised to 18 points.

These changes:
- move the Digital by Default Service Standard with 26 points
- add new Digital Service Standard content with 18 points
- provide a link from the new Digital Service Standard to the older Digital by Default Service Standard in the introduction
- provide a link back from the 26 point Digital by Default Service Standard to the new updated 18 point Service Standard in a status notice
- change 26 points to 18 points in the assessment criteria
