### PR TITLE
Remove Google Analytics classic

### DIFF
--- a/_includes/layouts/_body.html
+++ b/_includes/layouts/_body.html
@@ -1,9 +1,8 @@
 <script src="/service-manual/assets/javascript/jquery-1.7.2.js"></script>
 <script src="/service-manual/assets/javascript/jquery-ui-1.10.2.custom.js?cache={{ site.time | date: "%s" }}"></script>
 <script src="/service-manual/assets/toolkit/javascripts/vendor/jquery/jquery.player.min.js?cache={{ site.time | date: "%s" }}"></script>
-<script src="/service-manual/assets/toolkit/javascripts/govuk/analytics/google-analytics-classic-tracker.js?cache={{ site.time | date: "%s" }}"></script>
 <script src="/service-manual/assets/toolkit/javascripts/govuk/analytics/google-analytics-universal-tracker.js?cache={{ site.time | date: "%s" }}"></script>
-<script src="/service-manual/assets/toolkit/javascripts/govuk/analytics/tracker.js?cache={{ site.time | date: "%s" }}"></script>
+<script src="/service-manual/assets/toolkit/javascripts/govuk/analytics/analytics.js?cache={{ site.time | date: "%s" }}"></script>
 <script src="/service-manual/assets/javascript/analytics-init.js?cache={{ site.time | date: "%s" }}"></script>
 <script src="/service-manual/assets/javascript/toggler.js?cache={{ site.time | date: "%s" }}"></script>
 <script src="/service-manual/assets/javascript/media-player-loader.js?cache={{ site.time | date: "%s" }}"></script>

--- a/service-manual/assets/javascript/analytics-init.js
+++ b/service-manual/assets/javascript/analytics-init.js
@@ -1,17 +1,16 @@
 (function() {
   "use strict";
 
-  GOVUK.Tracker.load();
+  GOVUK.Analytics.load();
   var cookieDomain = (document.domain === 'www.gov.uk') ? '.www.gov.uk' : document.domain;
 
-  GOVUK.analytics = new GOVUK.Tracker({
-    universalId: 'UA-26179049-7',
-    classicId: 'UA-26179049-1',
+  GOVUK.analytics = new GOVUK.Analytics({
+    universalId: 'UA-26179049-1',
     cookieDomain: cookieDomain
   });
 
   if (window.devicePixelRatio) {
-    GOVUK.analytics.setDimension(11, window.devicePixelRatio, 'Pixel Ratio', 2);
+    GOVUK.analytics.setDimension(11, window.devicePixelRatio);
   }
 
   GOVUK.analytics.trackPageview();


### PR DESCRIPTION
__To be deployed 2 June.__

Following on from https://github.com/alphagov/govuk_frontend_toolkit/pull/194

* Bump govuk_frontend_toolkit to pull in latest analytics
* Remove references to classic tracker
* Remove classic specific arguments (eg custom variable name and scope)
* Update references of `GOVUK.Tracker` to `GOVUK.Analytics`