### PR TITLE
Make title unique for 26 point Digital by Default Service Standard

### DIFF
--- a/service-manual/digital-by-default-26-points/index.md
+++ b/service-manual/digital-by-default-26-points/index.md
@@ -1,6 +1,6 @@
 ---
 layout: standard
-title: Digital by Default Service Standard
+title: Digital by Default Service Standard (original 26 points)
 subtitle: Services so good that people prefer to use them
 audience:
   primary: service-manager


### PR DESCRIPTION
The title for the Digital by Default Service Standard was the same for
both the new 18 point standard and the older 26 point standard "Digital by Default Service Standard", 
this was causing two hero boxes (large red boxes) to be displayed on each
index page. 

Making the title unique for the 26 point standard fixes this.