### PR TITLE
Change wording about DKIM/SPF

### DIFF
--- a/service-manual/domain-names/email.md
+++ b/service-manual/domain-names/email.md
@@ -35,7 +35,7 @@ that you pass those checks. As a minimum you should:
 
 * ensure there is a [mail exchanger (MX) record](https://en.wikipedia.org/wiki/MX_record) set up for the domain from which you send email
 * enable [Sender Policy Framework (SPF)](https://en.wikipedia.org/wiki/Sender_Policy_Framework) on the sending domain
-* consider using [Domain Keys Identified Mail (DKIM)](https://en.wikipedia.org/wiki/DomainKeys_Identified_Mail) on the sending domain, it can provide additional guarantees about message delivery and help recipients to distinguish genuine mail from forgery
+* consider using [Domain Keys Identified Mail (DKIM)](https://en.wikipedia.org/wiki/DomainKeys_Identified_Mail) on the sending domain, it can provide additional guarantees about message authenticity and help recipients to distinguish genuine mail from forgery
 
 Before releasing your service you should test your email delivery. As a minimum you should use your service with
 registered email addresses from a range of popular email providers and ensure that emails arrive as you expect.

--- a/service-manual/operations/operating-servicegovuk-subdomains.md
+++ b/service-manual/operations/operating-servicegovuk-subdomains.md
@@ -132,7 +132,7 @@ Many suppliers offer IP forwarding DDOS protection, which does not have the same
 
 Emails to users of your service SHOULD be sent from a human-monitored email address that originates from the domain `servicename.service.gov.uk` (and not the dept/agency or any other domain name).
 
-You SHOULD enable [SPF](https://en.wikipedia.org/wiki/Sender_Policy_Framework) on the sending domain. You MAY also want to use [DKIM](http://www.dkim.org/) on the sending domain; it can provide additional guarantees about message delivery and help recipients to more easily distinguish genuine mail from forgery.
+You SHOULD enable [SPF](https://en.wikipedia.org/wiki/Sender_Policy_Framework) on the sending domain. You MAY also want to use [DKIM](http://www.dkim.org/) on the sending domain; it can provide additional guarantees about message authenticity and help recipients to more easily distinguish genuine mail from forgery.
 
 ## Lifecycle of service subdomains
 


### PR DESCRIPTION
SPF provides a public list of servers that you expect to be sending mail for
your domain. The recipient can check this list to determine whether the
server from which it has recieved mail is on the list and hence whether the
message is likely to be authentic. This method can be spoofed by careful editing
of the email Received-From header, so it is an indicator of authenticity, not
a guarantee.

DKIM (DomainKey Identified Mail) allows you to publish a public key in DNS and
to sign all your mail with your private key. The recipient can check that any
mail it receives are signed with that public key and hence can know that the
email it has received has been sent by the organisation in control of that
domain name. It is hard to forge unless you are in control of both the sending
server (and private key) and the domain name, but can be spoofed.

Neither of these two methods provide guarantees that a message will be delivered
successfully to the recipients mailbox. Some mail systems will tend to assign
higher degrees of confidence that messages are not spam to emails signed with
DKIM and from mailservers published in an SPF record, but it's still possible
for these messages to be flagged as spam due to the content or other factors.

This changes a single word - delivery - to authenticity. By providing more
information about the authenticity of our messages, we allow the destination to
make better choices about how to deliver and flag mail, but we still do not get
any guarantees about delivery.