### PR TITLE
Add display:block to #content to fix width in IE

### DIFF
--- a/service-manual/assets/stylesheets/layouts/_gsdm.scss
+++ b/service-manual/assets/stylesheets/layouts/_gsdm.scss
@@ -45,6 +45,7 @@ header.page-header {
 
 
 #content {
+  display: block;
   margin: 0 auto;
   max-width: 1020px;
   position: relative;


### PR DESCRIPTION
Here #content is styling the HTML5 `<main>` element, which isn’t [block by
default](http://caniuse.com/#feat=html5semantic). 

Set it to be block to fix the layout in IE - where the layout
is currently the full-width of the page.