### PR TITLE
Add Childcare and parenting link in footer

### DIFF
--- a/_includes/layouts/_footer_top.html
+++ b/_includes/layouts/_footer_top.html
@@ -5,13 +5,14 @@
       <li><a href="/browse/benefits">Benefits</a></li>
       <li><a href="/browse/births-deaths-marriages">Births, deaths, marriages and care</a></li>
       <li><a href="/browse/business">Business and self-employed</a></li>
+      <li><a href="/browse/childcare-parenting">Childcare and parenting</a></li>
       <li><a href="/browse/citizenship">Citizenship and living in the UK</a></li>
       <li><a href="/browse/justice">Crime, justice and the law</a></li>
       <li><a href="/browse/disabilities">Disabled people</a></li>
       <li><a href="/browse/driving">Driving and transport</a></li>
-      <li><a href="/browse/education">Education and learning</a></li>
     </ul>
     <ul>
+      <li><a href="/browse/education">Education and learning</a></li>
       <li><a href="/browse/employing-people">Employing people</a></li>
       <li><a href="/browse/environment-countryside">Environment and countryside</a></li>
       <li><a href="/browse/housing-local-services">Housing and local services</a></li>


### PR DESCRIPTION
This adds the link to the new "Childcare and parenting" browse page in the footer.

See PR on static for previous art: https://github.com/alphagov/static/pull/622