### PR TITLE
Properly capitalise DevOps

### DIFF
--- a/service-manual/operations/devops.md
+++ b/service-manual/operations/devops.md
@@ -1,6 +1,6 @@
 ---
 layout: detailed-guidance
-title: Devops
+title: DevOps
 subtitle: Bringing development and operations together
 category: operations
 type: guide
@@ -17,7 +17,7 @@ breadcrumbs:
     url: /service-manual/operations
 ---
 
-Devops is a cultural and professional movement in response to the mistakes commonly made by large organisations. Often organisations will have very separate units for:
+DevOps is a cultural and professional movement in response to the mistakes commonly made by large organisations. Often organisations will have very separate units for:
 
 * development
 * quality assurance
@@ -31,7 +31,7 @@ In extreme cases these units may be:
 
 Communication costs between these units, and their individual incentives, leads to slow delivery and a mountain of interconnected processes.
 
-This is what Devops aims to correct. It is not a methodology or framework, but a set of principles and a willingness to break down silos. Specifically Devops is all about:
+This is what DevOps aims to correct. It is not a methodology or framework, but a set of principles and a willingness to break down silos. Specifically DevOps is all about:
 
 * [culture](#culture)
 * [automation](#automation)
@@ -40,7 +40,7 @@ This is what Devops aims to correct. It is not a methodology or framework, but a
 
 ### Culture
 
-Devops needs a change in attitude so shared ownership and collaboration are the common working practices in building and managing a service. This culture change is especially important for established organisations.
+DevOps needs a change in attitude so shared ownership and collaboration are the common working practices in building and managing a service. This culture change is especially important for established organisations.
 
 ### Automation
 
@@ -62,7 +62,7 @@ Data can be incredibly powerful for implementing change, especially when it’s 
 
 People from different backgrounds (ie development and operations) often have different, but overlapping skill sets. Sharing between groups will spread an understanding of the different areas behind a successful service, so encourage it. Resolving issues will then be more about working together and not negotiating contracts.
 
-## Why Devops
+## Why DevOps
 
 The quality of your service will be compromised if teams can't work together, specifically:
 
@@ -87,7 +87,7 @@ Make sure the groups in your team:
 
 ## Good habits
 
-Devops isn’t a project management methodology, but use these good habits in your organisation. While not unique to Devops, they help with breaking down silos when used with the above principles:
+DevOps isn’t a project management methodology, but use these good habits in your organisation. While not unique to DevOps, they help with breaking down silos when used with the above principles:
 
 * [cross-functional teams](/service-manual/the-team) -- make sure your teams are made up of people from different functions (this helps with the team owning the end-to-end quality of service and makes it easier to break down silos)
 * [widely shared metrics](/service-manual/measurement) -- it’s important for everyone to know what ‘good’ looks like so share high and low level metrics as widely as possible as it builds understanding
@@ -99,15 +99,15 @@ Devops isn’t a project management methodology, but use these good habits in yo
 
 ## Warning signs
 
-Like agile, the term Devops is often used for marketing or promotional purposes. This leads to a few common usages, which aren’t necessarily in keeping with what’s been said here. Watch out for:
+Like agile, the term DevOps is often used for marketing or promotional purposes. This leads to a few common usages, which aren’t necessarily in keeping with what’s been said here. Watch out for:
 
-* Devops tools (nearly always marketing)
-* a Devops team (in many cases this is just a new silo of skills and knowledge)
-* Devops as a job title (you wouldn’t call someone “an agile”)
+* DevOps tools (nearly always marketing)
+* a DevOps team (in many cases this is just a new silo of skills and knowledge)
+* DevOps as a job title (you wouldn’t call someone “an agile”)
 
 ## Related guides in the Service Manual
 
-Those interested in Devops are often also interested in:
+Those interested in DevOps are often also interested in:
 
 * [Configuration Management](https://www.gov.uk/service-manual/making-software/configuration-management.html)
 * [Monitoring](https://www.gov.uk/service-manual/operations/monitoring.html)
@@ -115,7 +115,7 @@ Those interested in Devops are often also interested in:
 
 ## Further reading
 
-* [What Devops Means to Me](https://www.chef.io/blog/2010/07/16/what-devops-means-to-me/)
-* [what is this Devops thing anyway?](http://www.jedi.be/blog/2010/02/12/what-is-this-devops-thing-anyway/)
-* [what is Devops (and the wall of confusion)](http://dev2ops.org/2010/02/what-is-devops/)
-* [there’s no such thing as a "Devops Team"](http://continuousdelivery.com/2012/10/theres-no-such-thing-as-a-devops-team/)
+* [What DevOps Means to Me](https://www.chef.io/blog/2010/07/16/what-devops-means-to-me/)
+* [What is this DevOps thing anyway?](http://www.jedi.be/blog/2010/02/12/what-is-this-devops-thing-anyway/)
+* [What is DevOps? (and the wall of confusion)](http://dev2ops.org/2010/02/what-is-devops/)
+* [There’s no such thing as a "DevOps Team"](http://continuousdelivery.com/2012/10/theres-no-such-thing-as-a-devops-team/)

--- a/service-manual/operations/index.md
+++ b/service-manual/operations/index.md
@@ -26,7 +26,7 @@ breadcrumbs:
 * [Cloud security](/service-manual/operations/cloud-security)
 * [Monitoring](/service-manual/operations/monitoring)
 * [Hosting](/service-manual/operations/hosting)
-* [Devops](/service-manual/operations/devops)
+* [DevOps](/service-manual/operations/devops)
 * [Availability](/service-manual/operations/uptime-and-availability)
 * [Operating service.gov.uk subdomains](/service-manual/operations/operating-servicegovuk-subdomains)
 

--- a/service-manual/operations/service-management.md
+++ b/service-manual/operations/service-management.md
@@ -210,5 +210,5 @@ performance data, changes to best practice and service demand
 * [Functions in service management](http://www.slideshare.net/nuwulang/functions-in-service-operation)
 * [ITIL on Wikipedia](https://en.wikipedia.org/wiki/ITIL)
 * [Introduction to ITIL v3](http://www.best-management-practice.com/gempdf/itsmf_an_introductory_overview_of_itil_v3.pdf)
-* [Discussion of Devops and ITIL](http://blog.ingineering.it/post/59414765140/itil-vs-devops-slugfest-or-lovefest)
+* [Discussion of DevOps and ITIL](http://blog.ingineering.it/post/59414765140/itil-vs-devops-slugfest-or-lovefest)
 * [Discussion of ITIL and Continuous Delivery](http://changeandrelease.com/2014/04/05/devops-and-itil-continuous-delivery-doesnt-stop-at-software/)


### PR DESCRIPTION
DevOps is a portmanteau of 'development' and 'operations', and in some ways
is a good reflection of one of its core tenets. Since each word can be used
individually, we should style this correctly.

Colloboration amongs operations and development teams is central to DevOps,
so since neither party rules the roost all the time, we should capitalise
the start of each part of the portmanteau.