### PR TITLE
Really fix the displaying of bullet points in action_plan.md

### DIFF
--- a/service-manual/assisted-digital/action-plan.md
+++ b/service-manual/assisted-digital/action-plan.md
@@ -259,6 +259,7 @@ Before your service can go fully live on the GOV.UK domain, it must pass a live 
 To pass the live assessment, you must be able to show how you’ve built upon each phase - from discovery to alpha to the beta phases.
 
 You may need to discuss the following topics:
+
 * your user research, user testing and your service team
 * how you designed the assisted digital support elements of your service
 * how you analysed performance data and KPIs for your assisted digital support


### PR DESCRIPTION
- For the last time. _Please_. The GitHub markdown view link obviously
  failed when I couldn't find any asterisks in the preview of
  https://github.com/alphagov/government-service-design-manual/pull/611,
  'cause post-deploy today there were asterisks in this section instead of
  bullet points. :goat: 