### PR TITLE
Clarify - most (not all) services get start pages

### DIFF
--- a/service-manual/user-centred-design/resources/patterns/start-pages.md
+++ b/service-manual/user-centred-design/resources/patterns/start-pages.md
@@ -14,7 +14,9 @@ breadcrumbs:
 ---
 
 {:.intro}
-All services must have a starting point on GOV.UK. Usually (but not always), the best way to do this is to ask the GOV.UK content team to create a start page.
+All services must have a starting point on GOV.UK, unless they're 'invitation only' services.
+
+Usually (but not always), this will mean asking the GOV.UK content team to create a GOV.UK start page.
 
 Status: [Research required](#research)
 
@@ -102,7 +104,7 @@ Tell them:
 + a demo URL (with a username and password if necessary)
 + when the service is expected to pass its beta assessment
 
-They will either create a start page for you - or if that's not the best way of meeting the user need, recommend another way of joining up your service with GOV.UK.
+They will either create a start page for you - or if that's not the best way of meeting the user need, recommend another way of joining up your service with the rest of GOV.UK.
 
 Factor in time it'll take for the content to be written and fact-checked -
 a start page can only be published after both:

--- a/service-manual/user-centred-design/resources/patterns/start-pages.md
+++ b/service-manual/user-centred-design/resources/patterns/start-pages.md
@@ -14,8 +14,7 @@ breadcrumbs:
 ---
 
 {:.intro}
-Start pages are how people access transactions on GOV.UK. All services on GOV.UK must have a start page.
-
+All services must have a starting point on GOV.UK. Usually (but not always), the best way to do this is to ask the GOV.UK content team to create a start page.
 
 Status: [Research required](#research)
 
@@ -90,9 +89,9 @@ Use this to tell people about other ways that people can access the service.
 
 # Getting a start page on GOV.UK 
 
-When you're close to your beta launch, [contact the GOV.UK content team](https://support.production.alphagov.co.uk/new_feature_request/new) to ask for a start page.
+Well before your beta launch, [contact the GOV.UK content team](https://support.production.alphagov.co.uk/new_feature_request/new).
 
-You should tell them:
+Tell them:
 
 + what the service is and who it's for
 + what user needs it addresses
@@ -103,8 +102,10 @@ You should tell them:
 + a demo URL (with a username and password if necessary)
 + when the service is expected to pass its beta assessment
 
+They will either create a start page for you - or if that's not the best way of meeting the user need, recommend another way of joining up your service with GOV.UK.
+
 Factor in time it'll take for the content to be written and fact-checked -
-the start page can only be published after both:
+a start page can only be published after both:
 
 + the service passes its [beta assessment](https://www.gov.uk/service-manual/phases/beta.html) or self-certification
 + the service goes live


### PR DESCRIPTION
Based on further Hackpad discussion: https://designpatterns.hackpad.com/Start-pages-8fitVQYufJX

... tweaked the text to: (1) clarify that we'll usually create a start page for a new service, but only if it's the best way of meeting the user need; and (2) encourage service teams to get in touch with the content team sooner rather than later (in case we need some time to clarify the best way of joining up the service to GOV.UK).

What do you think, @timpaul ? 