### PR TITLE
Update browsers and devices page

### DIFF
--- a/service-manual/user-centred-design/browsers-and-devices.md
+++ b/service-manual/user-centred-design/browsers-and-devices.md
@@ -34,7 +34,9 @@ Browsers not listed may still work well, and it should be noted that this is not
 
 Services should ensure there's an obvious way for users to report problems they may find, and additional testing and adjustments should be made upon receiving such a report.
 
-Two distinct levels of support are given and denoted next to each browser. Where 'latest version' is listed, it means the latest stable version plus one version back, as these browsers regularly update without intervention from the user.
+Two distinct levels of support are given and denoted next to each browser: 'compliant' or 'functional'. Compliant means that the service should look as good in this browser as in other modern browsers. Functional means that while it might not look perfect the service is still usable. In both cases the user should be able to access the information they need or complete their service.
+
+Where 'latest version' is listed, it means the latest stable version plus one version back, as these browsers regularly update without intervention from the user.
 
 ### Desktop
 

--- a/service-manual/user-centred-design/browsers-and-devices.md
+++ b/service-manual/user-centred-design/browsers-and-devices.md
@@ -48,7 +48,7 @@ Two distinct levels of support are given and denoted next to each browser. Where
     <th scope="row" rowspan="4">Windows</th><td>Internet Explorer 8+</td><td>Compliant</td>
   </tr>
   <tr>
-    <td>Internet Explorer 7</td><td>Functional</td>
+    <td>Edge (latest version)</td><td>Compliant</td>
   </tr>
   <tr>
     <td>Google Chrome (latest version)</td><td>Compliant</td>
@@ -57,7 +57,7 @@ Two distinct levels of support are given and denoted next to each browser. Where
     <td>Mozilla Firefox (latest version)</td><td>Compliant</td>
   </tr>
   <tr>
-    <th scope="row" rowspan="3">Mac OS X</th><td>Safari 7+</td><td>Compliant</td>
+    <th scope="row" rowspan="3">Mac OS X</th><td>Safari 8+</td><td>Compliant</td>
   </tr>
   <tr>
     <td>Google Chrome (latest version)</td><td>Compliant</td>


### PR DESCRIPTION
This updates the browsers and devices page with the latest support information, and adds some explanatory text around compliant / functional (fixing https://github.com/alphagov/government-service-design-manual/issues/621).