### PR TITLE
Add a link to GOV.UK's Terms and Conditions to the footer

### DIFF
--- a/_includes/layouts/_footer_support_links.html
+++ b/_includes/layouts/_footer_support_links.html
@@ -2,6 +2,7 @@
   <li><a href="/help">Help</a></li>
   <li><a href="/help/cookies">Cookies</a></li>
   <li><a href="/contact">Contact</a></li>
+  <li><a href="/help/terms-conditions">Terms and conditions</a></li>
   <li><a href="/cymraeg">Rhestr o Wasanaethau Cymraeg</a></li>
   <li>Built by the <a href="https://www.gov.uk/government/organisations/government-digital-service">Government Digital Service</a></li>
 </ul>


### PR DESCRIPTION
- It was advised that we include this link prominently in the (rare)
  event of legal action against us for something on the site.
- Related to https://github.com/alphagov/static/pull/714.