### PR TITLE
Map CESG URLs to new paths following website upgrade

### DIFF
--- a/service-manual/making-software/information-security.md
+++ b/service-manual/making-software/information-security.md
@@ -137,7 +137,7 @@ Their role is to understand what information is held, what is added and what is 
 
 #### CESG (originally Communications Electronics Security Group)
 
-[CESG](https://www.cesg.gov.uk/Pages/homepage.aspx) are the government agency responsible for Information Security. They can provide technical assistance or consultation on project issues.
+[CESG](https://www.cesg.gov.uk) are the government agency responsible for Information Security. They can provide technical assistance or consultation on project issues.
 
 ### IT Health Check
 

--- a/service-manual/operations/penetration-testing.md
+++ b/service-manual/operations/penetration-testing.md
@@ -73,8 +73,8 @@ The web is a hostile environment, and the nature of government services means th
 
 Exploits of web application tend to follow a relatively small number of common patterns. Automated and manual testing, as well as awareness of these common problems, can have a drastic effect on the security of your system.
 
-[The Government Accreditation processes](https://www.cesg.gov.uk/policyguidance/PGA/Pages/index.aspx) mandate some form of vulnerability testing, often working with [CHECK approved suppliers](https://www.cesg.gov.uk/finda/Pages/CHECKSearch.aspx). View this as the minimum amount of effort required.
+[The Government Accreditation processes](https://www.cesg.gov.uk/articles/pan-government-accreditation-service-pga) mandate some form of vulnerability testing, often working with [CHECK approved suppliers](https://www.cesg.gov.uk/scheme/penetration-testing). View this as the minimum amount of effort required.
 
 ## Further reading
 
-* [OWASP Top 10](https://www.owasp.org/index.php/Top_10_2010)
+* [OWASP Top 10](https://www.owasp.org/index.php/OWASP_Top_10)


### PR DESCRIPTION
On 13/01/2016 the new CESG went live, looks like this broke these links
leaving them all (including the homepage) as 404s.

This commit updates them to what appears to be the best counterparts on
the new website.