### PR TITLE
Add missing apostrophes to 'users' where appropriate

### DIFF
--- a/_includes/_phases.html
+++ b/_includes/_phases.html
@@ -10,7 +10,7 @@
   <li class="alpha">
     <h3><a href="/service-manual/phases/alpha.html">Alpha</a></h3>
 
-    <p>A short phase in which you prototype solutions for your users needs. You’ll be testing with a small group of users or stakeholders, and getting early feedback about the design of the service.</p>
+    <p>A short phase in which you prototype solutions for your users' needs. You’ll be testing with a small group of users or stakeholders, and getting early feedback about the design of the service.</p>
 
     <p><a href="/service-manual/phases/alpha.html">Learn about the alpha phase</a></p>
 

--- a/service-manual/phases/alpha.md
+++ b/service-manual/phases/alpha.md
@@ -19,7 +19,7 @@ breadcrumbs:
 {:.intro}
 When designing a service it's impossible to predict everything upfront. Each project features many challenges, and in your alpha you will start exploring solutions for these.
 
-You may need to bring more [developers](/service-manual/the-team/developer) and [designers](/service-manual/the-team/designer) into [the team](/service-manual/the-team), who will help you to build and test [prototypes](/service-manual/user-centred-design/working-with-prototypes) and possible solutions for your [users needs](/service-manual/user-centred-design/user-needs).
+You may need to bring more [developers](/service-manual/the-team/developer) and [designers](/service-manual/the-team/designer) into [the team](/service-manual/the-team), who will help you to build and test [prototypes](/service-manual/user-centred-design/working-with-prototypes) and possible solutions for your [users' needs](/service-manual/user-centred-design/user-needs).
 
 By the end of the alpha you should have a clear idea of what's required to build a [beta](/service-manual/phases/beta). The whole phase should not last longer than about 6 to 8 weeks.
 


### PR DESCRIPTION
There are a couple of instances of the word users which should be users'