### PR TITLE
Update email guidance to refer to CTS email blueprint

### DIFF
--- a/service-manual/domain-names/email.md
+++ b/service-manual/domain-names/email.md
@@ -34,8 +34,9 @@ to use a trusted specialist third-party to dispatch email as they will have tool
 that you pass those checks. As a minimum you should:
 
 * ensure there is a [mail exchanger (MX) record](https://en.wikipedia.org/wiki/MX_record) set up for the domain from which you send email
-* enable [Sender Policy Framework (SPF)](https://en.wikipedia.org/wiki/Sender_Policy_Framework) on the sending domain
-* consider using [Domain Keys Identified Mail (DKIM)](https://en.wikipedia.org/wiki/DomainKeys_Identified_Mail) on the sending domain, it can provide additional guarantees about message authenticity and help recipients to distinguish genuine mail from forgery
+* implement the [Domain-based Message Authentication, Reporting and Conformance (DMARC)](https://www.gov.uk/government/publications/email-security-standards/domain-based-message-authentication-reporting-and-conformance-dmarc) standard to improve the likelihood that your email will be delivered correctly
 
 Before releasing your service you should test your email delivery. As a minimum you should use your service with
 registered email addresses from a range of popular email providers and ensure that emails arrive as you expect.
+
+For more on good practice on email in government, see the [Common Technology Services email blueprint](https://www.gov.uk/guidance/common-technology-services-cts-secure-email-blueprint)

--- a/service-manual/operations/operating-servicegovuk-subdomains.md
+++ b/service-manual/operations/operating-servicegovuk-subdomains.md
@@ -132,7 +132,7 @@ Many suppliers offer IP forwarding DDOS protection, which does not have the same
 
 Emails to users of your service SHOULD be sent from a human-monitored email address that originates from the domain `servicename.service.gov.uk` (and not the dept/agency or any other domain name).
 
-You SHOULD enable [SPF](https://en.wikipedia.org/wiki/Sender_Policy_Framework) on the sending domain. You MAY also want to use [DKIM](http://www.dkim.org/) on the sending domain; it can provide additional guarantees about message authenticity and help recipients to more easily distinguish genuine mail from forgery.
+You SHOULD apply the [Common Technology Services email blueprint](https://www.gov.uk/guidance/common-technology-services-cts-secure-email-blueprint) on the sending domain, including implementing [Domain-based Message Authentication, Reporting and Conformance (DMARC)](https://www.gov.uk/government/publications/email-security-standards/domain-based-message-authentication-reporting-and-conformance-dmarc).
 
 ## Lifecycle of service subdomains
 


### PR DESCRIPTION
CTS has recently published a blueprint for email configuration, including the use of DMARC which includes SPF and DKIM. We should be linking to that rather than have separate email server config guidance.