### PR TITLE
Exclude agile delivery from the search index

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ The following keys are used throughout:
 | `audience: secondary:` | | Secondary audience. Link to page will appear in bottom half of audience index |
 | `phases:` | `discovery`, `alpha`, `beta`, `live` | An array of values. Adds links to page header and lists pages in relevant phase page |
 | `breadcrumbs:` | An array of objects with `title:` and `url:` values | Adds a breadcrumb trail to the top of the page |
+| `exclude_from_search:` | `true` | Exclude the page from search. The default behaviour is to include the page in search. |
 
 Index page meta data
 --------------------

--- a/service-manual/agile/features-of-agile.md
+++ b/service-manual/agile/features-of-agile.md
@@ -19,6 +19,7 @@ breadcrumbs:
   -
     title: Agile
     url: /service-manual/agile
+exclude_from_search: true
 ---
 
 Some common features of the agile development methods we’ve used at GDS.

--- a/service-manual/agile/index.md
+++ b/service-manual/agile/index.md
@@ -17,6 +17,7 @@ breadcrumbs:
   -
     title: Home
     url: /service-manual
+exclude_from_search: true
 ---
 
 Agile methodologies will help you and your team to build world-class, user-centred services quickly and affordably. 

--- a/service-manual/agile/running-retrospectives.md
+++ b/service-manual/agile/running-retrospectives.md
@@ -19,6 +19,7 @@ breadcrumbs:
   -
     title: Agile
     url: /service-manual/agile
+exclude_from_search: true
 ---
 
 A central principle of agile is quick feedback loops -- you demonstrate something to the user as soon as possible so you can see how well it suits their needs. Retrospectives are the way we apply this to our own teams to find out what’s working and what isn’t, so a team can continuously improve.

--- a/service-manual/agile/what-agile-looks-like.md
+++ b/service-manual/agile/what-agile-looks-like.md
@@ -20,6 +20,7 @@ breadcrumbs:
   -
     title: Agile
     url: /service-manual/agile
+exclude_from_search: true
 ---
 
 Agile can be a liberating way of working. It won’t stop you from using existing skills and knowledge, but it will require your team, users and stakeholders to start working together in new ways.

--- a/service-manual/agile/writing-user-stories.md
+++ b/service-manual/agile/writing-user-stories.md
@@ -20,6 +20,7 @@ breadcrumbs:
   -
     title: Agile
     url: /service-manual/agile
+exclude_from_search: true
 ---
 
 A user story briefly explains:

--- a/service-manual/governance/governance-principles.md
+++ b/service-manual/governance/governance-principles.md
@@ -19,6 +19,7 @@ breadcrumbs:
   -
     title: Governance
     url: /service-manual/governance
+exclude_from_search: true
 ---
 
 GDS has defined 6 principles for governing service delivery. Following them should help you create the right culture within your service. They are:

--- a/service-manual/governance/how-delivery-teams-manage-their-work.md
+++ b/service-manual/governance/how-delivery-teams-manage-their-work.md
@@ -19,6 +19,7 @@ breadcrumbs:
   -
     title: Governance
     url: /service-manual/governance
+exclude_from_search: true
 ---
 
 Teams using agile approaches often manage their work on a wall in their work area. The wall creates a physical focus for the team and for collaboration -- people gather round it at their daily stand-up and refer to and update it during the day. This lets them collaborate effectively with each other and shows the status of their work to anyone who looks at the wall. This is called ‘visual management’. 

--- a/service-manual/governance/seeing-progress.md
+++ b/service-manual/governance/seeing-progress.md
@@ -19,6 +19,7 @@ breadcrumbs:
   -
     title: Governance
     url: /service-manual/governance
+exclude_from_search: true
 ---
 
 

--- a/service-manual/governance/setting-up-the-right-reporting.md
+++ b/service-manual/governance/setting-up-the-right-reporting.md
@@ -19,6 +19,7 @@ breadcrumbs:
   -
     title: Governance
     url: /service-manual/governance
+exclude_from_search: true
 ---
 
 ###Getting started

--- a/service-manual/governance/what-to-expect-from-the-show-and-tell.md
+++ b/service-manual/governance/what-to-expect-from-the-show-and-tell.md
@@ -19,6 +19,7 @@ breadcrumbs:
   -
     title: Governance
     url: /service-manual/governance
+exclude_from_search: true
 ---
 
 ###Why you should go to show and tells

--- a/service-manual/the-team/working-environment.md
+++ b/service-manual/the-team/working-environment.md
@@ -17,6 +17,7 @@ breadcrumbs:
   -
     title: The team
     url: /service-manual/the-team
+exclude_from_search: true
 ---
 
 Working spaces for digital projects will vary, but there are some things you can do to ensure that the space you have available can be used in the way your team needs.


### PR DESCRIPTION
As we migrate sections away from the old service manual we need to stop indexing the old service manual in search.

Metadata can be added to each page or an array of patterns to exclude from search can be defined in config.yml.

This documents the metadata which we think for the moment is safer and easier to manage than the patterns in config.

The agile delivery section has already been migrated away from the old service manual to the new one. This adds the metadata to the related agile delivery pages.