### PR TITLE
Replacing broken hackpad link

### DIFF
--- a/service-manual/governance/assurance-for-digital-services.md
+++ b/service-manual/governance/assurance-for-digital-services.md
@@ -74,5 +74,5 @@ Assurance should be done in line with the governance principles for digital serv
 
 **Get involved**
 
-To give feedback, make a suggestion or share your experience, use the [governance guidance hackpad](https://gds-governance-guidance.hackpad.com/Assurance-for-digital-services-mnH2GMxxMGD).
+To give feedback, make a suggestion or share your experience, use the [governance guidance hackpad](https://gds-governance-guidance.hackpad.com/Introduction-to-governance-for-service-delivery-KvxJZEmVmdb).
 


### PR DESCRIPTION
Previous link to  "[Assurance](https://gds-governance-guidance.hackpad.com/Assurance-for-digital-services-mnH2GMxxMGD)" hackpad is no longer valid as this resource has been deleted

Proposing that this is replaced with a link to the "[Governance](https://gds-governance-guidance.hackpad.com/Introduction-to-governance-for-service-delivery-KvxJZEmVmdb)" hackpad. This is actually the one already referenced in the title of this link.