### PR TITLE
Remove from search content migrated prior to 2016-04-08

### DIFF
--- a/service-manual/governance/introduction-to-governance-for-service-delivery.md
+++ b/service-manual/governance/introduction-to-governance-for-service-delivery.md
@@ -16,6 +16,7 @@ breadcrumbs:
   -
     title: Home
     url: /service-manual
+exclude_from_search: true
 ---
 
 ###What governance is and why we need it

--- a/service-manual/governance/scaling-a-service-team.md
+++ b/service-manual/governance/scaling-a-service-team.md
@@ -19,6 +19,7 @@ breadcrumbs:
   -
     title: Governance
     url: /service-manual/governance
+exclude_from_search: true
 ---
 
 ###Scaling a service team

--- a/service-manual/governance/when-to-scale-up.md
+++ b/service-manual/governance/when-to-scale-up.md
@@ -19,6 +19,7 @@ breadcrumbs:
   -
     title: Governance
     url: /service-manual/governance
+exclude_from_search: true
 ---
 
 You should only consider scaling up when everyone is already working well together. Adding more people, particularly when done quickly, is likely to magnify any problems if the team isn’t working well.

--- a/service-manual/measurement/completion-rate.md
+++ b/service-manual/measurement/completion-rate.md
@@ -18,6 +18,7 @@ breadcrumbs:
   -
     title: Measurement
     url: /service-manual/measurement
+exclude_from_search: true
 ---
 
 Completion rate shows how many people manage to use the service successfully.

--- a/service-manual/measurement/cost-per-transaction.md
+++ b/service-manual/measurement/cost-per-transaction.md
@@ -18,6 +18,7 @@ breadcrumbs:
   -
     title: Measurement
     url: /service-manual/measurement
+exclude_from_search: true
 ---
 
 Cost per transaction is an important measure of a service’s efficiency. As services become more efficient, the cost per transaction will fall.

--- a/service-manual/measurement/digital-takeup.md
+++ b/service-manual/measurement/digital-takeup.md
@@ -18,6 +18,7 @@ breadcrumbs:
   -
     title: Measurement
     url: /service-manual/measurement
+exclude_from_search: true
 ---
 
 Digital take-up is a long term strategic measure of how well digital by default service is working. You'll monitor this on a monthly basis to track that it's on course with the desired performance levels.

--- a/service-manual/measurement/index.md
+++ b/service-manual/measurement/index.md
@@ -17,6 +17,7 @@ breadcrumbs:
   -
     title: Home
     url: /service-manual
+exclude_from_search: true
 ---
 
 It’s essential to measure how your service is performing, so you can make sure that your service continues to meet user needs in a cost-effective and efficient way.

--- a/service-manual/measurement/other-kpis.md
+++ b/service-manual/measurement/other-kpis.md
@@ -18,6 +18,7 @@ breadcrumbs:
   -
     title: Measurement
     url: /service-manual/measurement
+exclude_from_search: true
 ---
 
 Your service must measure [the 4 key performance indicators](/service-manual/measurement/index.html).

--- a/service-manual/measurement/performance-platform.md
+++ b/service-manual/measurement/performance-platform.md
@@ -18,6 +18,7 @@ breadcrumbs:
   -
     title: Measurement
     url: /service-manual/measurement/performance-platform
+exclude_from_search: true
 ---
 
 The [Performance Platform](https://www.gov.uk/performance) is for service

--- a/service-manual/measurement/user-satisfaction.md
+++ b/service-manual/measurement/user-satisfaction.md
@@ -18,6 +18,7 @@ breadcrumbs:
   -
     title: Measurement
     url: /service-manual/measurement
+exclude_from_search: true
 ---
 
 Measuring user satisfaction helps you to gauge the overall quality of your service.

--- a/service-manual/the-team/index.md
+++ b/service-manual/the-team/index.md
@@ -14,6 +14,7 @@ breadcrumbs:
   -
     title: Home
     url: /service-manual
+exclude_from_search: true
 ---
 
 The right team needs to be in place to deliver a digital by default service. Teams are multidisciplinary, meet regularly, and often work close together to deliver rapid iterations of user-centred products.

--- a/service-manual/the-team/learning-and-development/foundation-day.md
+++ b/service-manual/the-team/learning-and-development/foundation-day.md
@@ -22,6 +22,7 @@ breadcrumbs:
   -
     title: Learning and development
     url: /service-manual/the-team/learning-and-development
+exclude_from_search: true
 ---
 
 #Who should take part

--- a/service-manual/the-team/learning-and-development/index.md
+++ b/service-manual/the-team/learning-and-development/index.md
@@ -19,6 +19,7 @@ breadcrumbs:
   -
     title: The team
     url: /service-manual/the-team
+exclude_from_search: true
 ---
 
 GDS offers 3 highly practical learning and development programmes so you can strengthen the skills, knowledge and network you will need to succeed in your digital role.

--- a/service-manual/the-team/learning-and-development/service-manager-induction.md
+++ b/service-manual/the-team/learning-and-development/service-manager-induction.md
@@ -22,6 +22,7 @@ breadcrumbs:
   -
     title: Learning and development
     url: /service-manual/the-team/learning-and-development
+exclude_from_search: true
 ---
 
 | Cohort   | Dates                                                |

--- a/service-manual/the-team/recruitment/index.md
+++ b/service-manual/the-team/recruitment/index.md
@@ -20,6 +20,7 @@ breadcrumbs:
   -
     title: The team
     url: /service-manual/the-team
+exclude_from_search: true
 ---
 
 

--- a/service-manual/the-team/recruitment/performance-analyst-jd.md
+++ b/service-manual/the-team/recruitment/performance-analyst-jd.md
@@ -13,6 +13,7 @@ breadcrumbs:
   -
     title: The team
     url: /service-manual/the-team
+exclude_from_search: true
 ---
 
 ## Job description

--- a/service-manual/the-team/working-with-specialists.md
+++ b/service-manual/the-team/working-with-specialists.md
@@ -17,6 +17,7 @@ breadcrumbs:
   -
     title: The team
     url: /service-manual/the-team
+exclude_from_search: true
 ---
 
 You may need specialist help to design, develop, build or improve your service. When buying in these services, there's support GDS may be able to provide.

--- a/service-manual/user-centred-design/user-research/user-research-briefs.md
+++ b/service-manual/user-centred-design/user-research/user-research-briefs.md
@@ -21,6 +21,7 @@ breadcrumbs:
   -
     title: User research
     url: /service-manual/user-centred-design/user-research
+exclude_from_search: true
 ---
 
 A Research brief is a document written to explain research requirements and enable research to be procured via third party agencies. A research brief will outline the research objectives, and why the work is required.


### PR DESCRIPTION
Periodically we remove pages from search that have been migrated to the new service manual so they do not appear in search twice.