### PR TITLE
Remove from search content migrated prior to 2016-06-02

### DIFF
--- a/service-manual/agile/quality.md
+++ b/service-manual/agile/quality.md
@@ -20,6 +20,7 @@ breadcrumbs:
   -
     title: Agile
     url: /service-manual/agile
+exclude_from_search: true
 ---
 
 Put quality at the forefront of your project if you want people to use and enjoy your service.

--- a/service-manual/assisted-digital/action-plan.md
+++ b/service-manual/assisted-digital/action-plan.md
@@ -19,6 +19,7 @@ breadcrumbs:
   -
     title: Assisted digital
     url: /service-manual/assisted-digital
+exclude_from_search: true
 ---
 Find out [what assisted digital support is](https://www.gov.uk/service-manual/assisted-digital), and whether you need to include it in your service design.
 

--- a/service-manual/assisted-digital/assisted-digital-user-research.md
+++ b/service-manual/assisted-digital/assisted-digital-user-research.md
@@ -19,6 +19,7 @@ breadcrumbs:
   -
     title: Assisted digital
     url: /service-manual/assisted-digital
+exclude_from_search: true
 ---
 
 ##Researching assisted digital users -- a guide for service managers

--- a/service-manual/assisted-digital/index.md
+++ b/service-manual/assisted-digital/index.md
@@ -16,6 +16,7 @@ breadcrumbs:
   -
     title: Home
     url: /service-manual
+exclude_from_search: true
 ---
 
 Service teams must ensure appropriate assisted digital support is in place for their service. This support must be aimed towards users who need it. [Read more about how to develop assisted digital support that meets the Digital Service Standard](https://www.gov.uk/service-manual/assisted-digital/action-plan).

--- a/service-manual/communications/increasing-digital-takeup.md
+++ b/service-manual/communications/increasing-digital-takeup.md
@@ -12,6 +12,7 @@ breadcrumbs:
   -
     title: Home
     url: /service-manual
+exclude_from_search: true
 ---
 
 It’s essential to increase the take-up of government digital services so more users can benefit from improved government services. Increased take-up will also make it possible for [assisted digital](/service-manual/assisted-digital/index.html) support to be focused on those who are unable to use the digital service.

--- a/service-manual/digital-by-default/assessments-at-gds.md
+++ b/service-manual/digital-by-default/assessments-at-gds.md
@@ -15,6 +15,7 @@ breadcrumbs:
   -
     title: Digital by Default Service Standard
     url: /service-manual/digital-by-default
+exclude_from_search: true
 ---
 
 Assessments for services that have (or are likely to have) more than 100,000 transactions a year are completed by GDS. Planning ahead is very important as it can take up to 4 weeks to complete the assessment process.

--- a/service-manual/digital-by-default/awarding-the-standard.md
+++ b/service-manual/digital-by-default/awarding-the-standard.md
@@ -15,6 +15,7 @@ breadcrumbs:
   -
     title: Digital by Default Service Standard
     url: /service-manual/digital-by-default
+exclude_from_search: true
 ---
 
 All services within the [scope of the standard](/service-manual/digital-by-default/scope-of-the-standard.html) will be assessed against the [criteria of the standard](/service-manual/digital-by-default). This includes the [25 exemplar services](https://www.gov.uk/transformation).

--- a/service-manual/digital-by-default/failure-to-meet-the-standard.md
+++ b/service-manual/digital-by-default/failure-to-meet-the-standard.md
@@ -15,6 +15,7 @@ breadcrumbs:
   -
     title: Digital by Default Service Standard
     url: /service-manual/digital-by-default
+exclude_from_search: true
 ---
 
 A service may fail to meet [the standard](/service-manual/digital-by-default/index.html) at three points:

--- a/service-manual/digital-by-default/scope-of-the-standard.md
+++ b/service-manual/digital-by-default/scope-of-the-standard.md
@@ -15,6 +15,7 @@ breadcrumbs:
   -
     title: Digital by Default Service Standard
     url: /service-manual/digital-by-default
+exclude_from_search: true
 ---
 
 While the information and guidance within the manual will be useful for teams in all services, [the standard](/service-manual/digital-by-default) itself will not apply to all government services. As described in the [Government Digital Strategy](/government/collections/government-digital-strategy-reports-and-research), only high-volume transactions being released after April 2014 will need to meet it.

--- a/service-manual/digital-by-default/self-certification.md
+++ b/service-manual/digital-by-default/self-certification.md
@@ -15,6 +15,7 @@ breadcrumbs:
   -
     title: Digital by Default Service Standard
     url: /service-manual/digital-by-default
+exclude_from_search: true
 ---
 
 Assessments for services that have (or are likely to have) fewer than 100,000 transactions a year are completed by an assessor within the service’s responsible department. The department will be responsible for the assessment of a service and the process to arrange this will vary by department. The digital leader will then certify the service conforms to the Digital by Default service standard.

--- a/service-manual/domain-names/https.md
+++ b/service-manual/domain-names/https.md
@@ -19,6 +19,7 @@ breadcrumbs:
   -
     title: Where services live on the web
     url: /service-manual/domain-names
+exclude_from_search: true
 ---
 
 ## HTTPS

--- a/service-manual/making-software/choosing-technology.md
+++ b/service-manual/making-software/choosing-technology.md
@@ -19,6 +19,7 @@ breadcrumbs:
   -
     title: Making software
     url: /service-manual/making-software
+exclude_from_search: true
 ---
 
 This is for guidance purposes only, so don’t take it as legal advice.

--- a/service-manual/making-software/configuration-management.md
+++ b/service-manual/making-software/configuration-management.md
@@ -19,6 +19,7 @@ breadcrumbs:
   -
     title: Making software
     url: /service-manual/making-software
+exclude_from_search: true
 ---
 
 Configuration management is about managing how the pieces of your software and/or service work together.

--- a/service-manual/making-software/dependency-management.md
+++ b/service-manual/making-software/dependency-management.md
@@ -18,6 +18,7 @@ breadcrumbs:
   -
     title: Making software
     url: /service-manual/making-software
+exclude_from_search: true
 ---
 
 Most software projects, especially those using open source technologies, will

--- a/service-manual/making-software/development-environment.md
+++ b/service-manual/making-software/development-environment.md
@@ -19,6 +19,7 @@ breadcrumbs:
   -
     title: Making software
     url: /service-manual/making-software
+exclude_from_search: true
 ---
 
 As software developers, the environments we use every day matter greatly. Below are a set of guidelines for development environments to enable the [exemplar projects][] (service transformations committed to in the [Government Digital Strategy](/government/publications/government-digital-strategy)) to:

--- a/service-manual/making-software/exploratory-testing.md
+++ b/service-manual/making-software/exploratory-testing.md
@@ -19,6 +19,7 @@ breadcrumbs:
   -
     title: Making software
     url: /service-manual/making-software
+exclude_from_search: true
 ---
 
 The goal of exploratory testing is to explore a system as a user would, possibly finding new defects as you go.

--- a/service-manual/making-software/progressive-enhancement.md
+++ b/service-manual/making-software/progressive-enhancement.md
@@ -18,6 +18,7 @@ breadcrumbs:
   -
     title: Making software
     url: /service-manual/making-software
+exclude_from_search: true
 ---
 
 When creating web pages, the only part of a page that you can rely upon working is the HTML. Even that can fail, but without HTML there is no web page and everything else becomes moot. The attitude towards building for the web with this in mind is called [progressive enhancement](https://en.wikipedia.org/wiki/Progressive_enhancement).

--- a/service-manual/making-software/sandbox-and-staging-servers.md
+++ b/service-manual/making-software/sandbox-and-staging-servers.md
@@ -18,6 +18,7 @@ breadcrumbs:
   -
     title: Making software
     url: /service-manual/making-software
+exclude_from_search: true
 ---
 
 Everyone working on the design, development or maintenance of your service should have a clear, easily accessible place to review the latest version of the software. Those working hands-on to build the software should be able to run their own reasonable replica of the entire service.

--- a/service-manual/making-software/testing-in-agile.md
+++ b/service-manual/making-software/testing-in-agile.md
@@ -20,6 +20,7 @@ breadcrumbs:
   -
     title: Making software
     url: /service-manual/making-software
+exclude_from_search: true
 ---
 
 The basics of any testing approach still apply in the agile world, but the aim of testing can be quite different.

--- a/service-manual/making-software/version-control.md
+++ b/service-manual/making-software/version-control.md
@@ -19,6 +19,7 @@ breadcrumbs:
   -
     title: Making software
     url: /service-manual/making-software
+exclude_from_search: true
 ---
 
 Every software development project has to use a version control system. Version control allows you to track changes to code over time, which means you can:

--- a/service-manual/operations/load-and-performance-testing.md
+++ b/service-manual/operations/load-and-performance-testing.md
@@ -15,6 +15,7 @@ breadcrumbs:
   -
     title: Operations
     url: /service-manual/operations
+exclude_from_search: true
 ---
 
 History is littered with countless government projects that collapsed under load or worked so slowly it frustrated users.

--- a/service-manual/operations/monitoring.md
+++ b/service-manual/operations/monitoring.md
@@ -15,6 +15,7 @@ breadcrumbs:
   -
     title: Operations
     url: /service-manual/operations
+exclude_from_search: true
 ---
 
 Any online application should have tools dedicated to alerting any problems to those running the service. These can be low-level issues involving the infrastructure supporting the service, to a sudden high rate of user errors.

--- a/service-manual/operations/penetration-testing.md
+++ b/service-manual/operations/penetration-testing.md
@@ -15,6 +15,7 @@ breadcrumbs:
   -
     title: Operations
     url: /service-manual/operations
+exclude_from_search: true
 ---
 
 Making sure your web-based systems and applications are secure requires more than just good design and development.

--- a/service-manual/operations/uptime-and-availability.md
+++ b/service-manual/operations/uptime-and-availability.md
@@ -15,6 +15,7 @@ breadcrumbs:
   -
     title: Operations
     url: /service-manual/operations
+exclude_from_search: true
 ---
 
 

--- a/service-manual/performance-analysts/index.md
+++ b/service-manual/performance-analysts/index.md
@@ -8,4 +8,5 @@ breadcrumbs:
   -
     title: Home
     url: /service-manual
+exclude_from_search: true
 ---

--- a/service-manual/technology/architecture.md
+++ b/service-manual/technology/architecture.md
@@ -14,6 +14,7 @@ breadcrumbs:
   -
     title: Chief technology officer
     url: /service-manual/technology
+exclude_from_search: true
 ---
 
 Architecture is not just about the design and deployment of technology -- to be successful you need to consider the utility, sustainability and attractiveness of the system as a whole. 

--- a/service-manual/technology/spending-controls.md
+++ b/service-manual/technology/spending-controls.md
@@ -20,6 +20,7 @@ breadcrumbs:
   -
     title: Technology
     url: /service-manual/technology
+exclude_from_search: true
 ---
 
 Organisations should follow the rules set out in [Managing public money](/government/publications/managing-public-money) which explains the overriding principles for dealing with resources used by public sector organisations in the UK.

--- a/service-manual/user-centred-design/accessibility.md
+++ b/service-manual/user-centred-design/accessibility.md
@@ -20,6 +20,7 @@ breadcrumbs:
   -
     title: User-centred design
     url: /service-manual/user-centred-design
+exclude_from_search: true
 ---
 
 The services we provide are for the benefit of all citizens of the United Kingdom. No user should be excluded on the basis of disability. To do so would breach the [Equality Act 2010](http://www.legislation.gov.uk/ukpga/2010/15/contents). Your services must also comply with any other legal requirements, including providing services in accordance with your Welsh Language Scheme, if you have one.

--- a/service-manual/user-centred-design/browsers-and-devices.md
+++ b/service-manual/user-centred-design/browsers-and-devices.md
@@ -18,6 +18,7 @@ breadcrumbs:
   -
     title: User-centred design
     url: /service-manual/user-centred-design
+exclude_from_search: true
 ---
 
 Services should be universally accessible, regardless of how the user is choosing to access them.

--- a/service-manual/user-centred-design/user-needs.md
+++ b/service-manual/user-centred-design/user-needs.md
@@ -20,6 +20,7 @@ breadcrumbs:
   -
     title: User-centred design
     url: /service-manual/user-centred-design
+exclude_from_search: true
 ---
 
 Deep understanding of your users' needs is crucial for building a successful digital service.

--- a/service-manual/user-centred-design/user-research/index.md
+++ b/service-manual/user-centred-design/user-research/index.md
@@ -19,6 +19,7 @@ breadcrumbs:
   -
     title: User-centred design
     url: /service-manual/user-centred-design
+exclude_from_search: true
 ---
 
 <figure class="media-player-wrapper video"><a href="https://www.youtube.com/watch?v=1hbnPCdM4ls">Watch Angela Collins-Rees, GDS User Research Specialist, describing the importance of user research.</a></figure>

--- a/service-manual/user-researchers/index.md
+++ b/service-manual/user-researchers/index.md
@@ -8,4 +8,5 @@ breadcrumbs:
   -
     title: Home
     url: /service-manual
+exclude_from_search: true
 ---


### PR DESCRIPTION
Periodically we remove pages from search that have been migrated to the new service manual so they do not appear in search twice.