### PR TITLE
Use the main gov.uk /search endpoint with filter_manual

### DIFF
--- a/_includes/layouts/_inside_header.html
+++ b/_includes/layouts/_inside_header.html
@@ -1,8 +1,9 @@
 <a href="#search" class="search-toggle js-header-toggle">Search</a>
-<form id="search" class="site-search" action="/service-manual/search" method="get">
+<form id="search" class="site-search" action="/search" method="get" role="search">
     <div class="content">
       <label for="site-search-text">Search the service manual</label>
       <input type="search" name="q" id="site-search-text" title="Search" class="js-search-focus" role="search">
+      <input type="hidden" name="filter_manual" value="/service-manual">
       <input class="submit" type="submit" value="Search" />
     </div>
 </form>

--- a/_search/includes/layouts/_inside_header.liquid
+++ b/_search/includes/layouts/_inside_header.liquid
@@ -1,8 +1,9 @@
 <a href="#search" class="search-toggle js-header-toggle">Search</a>
-<form id="search" class="site-search" action="/service-manual/search" method="get">
+<form id="search" class="site-search" action="/search" method="get" role="search">
     <div class="content">
       <label for="site-search-text">Search the service manual</label>
       <input type="search" name="q" id="site-search-text" title="Search" class="js-search-focus" role="search">
+      <input type="hidden" name="filter_manual" value="/service-manual">
       <input class="submit" type="submit" value="Search" />
     </div>
 </form>


### PR DESCRIPTION
This behaviour matches the new manual and thus tackles the fragmentation of search between the old and new manuals.