### PR TITLE
Remove from search content migrated prior to 2016-08-15

### DIFF
--- a/service-manual/digital-by-default/index.md
+++ b/service-manual/digital-by-default/index.md
@@ -12,6 +12,7 @@ breadcrumbs:
   -
     title: Home
     url: /service-manual
+exclude_from_search: true
 ---
 
 <div class="intro">

--- a/service-manual/making-software/deployment.md
+++ b/service-manual/making-software/deployment.md
@@ -18,6 +18,7 @@ breadcrumbs:
   -
     title: Making software
     url: /service-manual/making-software
+exclude_from_search: true
 ---
 # Principles for software deployment
 

--- a/service-manual/operations/hosting.md
+++ b/service-manual/operations/hosting.md
@@ -15,6 +15,7 @@ breadcrumbs:
   -
     title: Operations
     url: /service-manual/operations
+exclude_from_search: true
 ---
 
 You need servers to run your software. The information here will help you decide how you host your applications and the things to consider when selecting a vendor.

--- a/service-manual/phases/alpha.md
+++ b/service-manual/phases/alpha.md
@@ -14,6 +14,7 @@ breadcrumbs:
   -
     title: Phases of service design
     url: /service-manual/phases
+exclude_from_search: true
 ---
 
 {:.intro}

--- a/service-manual/phases/beta.md
+++ b/service-manual/phases/beta.md
@@ -14,6 +14,7 @@ breadcrumbs:
   -
     title: Phases of service design
     url: /service-manual/phases
+exclude_from_search: true
 ---
 
 {:.intro}

--- a/service-manual/phases/discovery.md
+++ b/service-manual/phases/discovery.md
@@ -14,6 +14,7 @@ breadcrumbs:
   -
     title: Service design phases
     url: /service-manual/phases
+exclude_from_search: true
 ---
 
 {:.intro}

--- a/service-manual/phases/ideal-alphas.md
+++ b/service-manual/phases/ideal-alphas.md
@@ -17,6 +17,7 @@ breadcrumbs:
   -
     title: Ideal Alphas
     url: /service-manual/phases/ideal-alphas
+exclude_from_search: true
 ---
 
 

--- a/service-manual/phases/live.md
+++ b/service-manual/phases/live.md
@@ -14,6 +14,7 @@ breadcrumbs:
   -
     title: Phases of service design
     url: /service-manual/phases
+exclude_from_search: true
 ---
 
 {:.intro}

--- a/service-manual/phases/retirement.md
+++ b/service-manual/phases/retirement.md
@@ -12,6 +12,7 @@ breadcrumbs:
   -
     title: Phases of service design
     url: /service-manual/phases
+exclude_from_search: true
 ---
 
 {:.intro}


### PR DESCRIPTION
Periodically we remove pages from search that have been migrated to the new service manual so they do not appear in search twice.

This removes the following migrated urls:

- /service-manual/operations/hosting.html
- /service-manual/operations/hosting
- /service-manual/making-software/deployment.html
- /service-manual/making-software/deployment
- /service-manual/phases/retirement.html
- /service-manual/phases/retirement
- /service-manual/phases/live.html
- /service-manual/phases/live
- /service-manual/phases/beta.html
- /service-manual/phases/beta
- /service-manual/phases/ideal-alphas.html
- /service-manual/phases/alpha.html
- /service-manual/phases/alpha
- /service-manual/phases/ideal-alphas
- /service-manual/phases/discovery.html
- /service-manual/phases/discovery
- /service-manual/digital-by-default.html
- /service-manual/digital-by-default
- /service-manual/digital-by-default/index.html
- /service-manual/digital-by-default/index